### PR TITLE
Remove system info from being reported in /debug/vars.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/rs/cors v1.5.0
 	github.com/rs/zerolog v1.9.1
 	github.com/sasha-s/go-IBLT v0.0.0-20150527092913-0d7bd59e8167
-	github.com/shirou/gopsutil v2.17.12+incompatible
 	github.com/stretchr/testify v1.2.2
 	github.com/urfave/cli v1.20.0
 	go.uber.org/atomic v1.3.2 // indirect

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -3,10 +3,6 @@ package stats
 import (
 	"expvar"
 	"time"
-
-	"github.com/shirou/gopsutil/cpu"
-	"github.com/shirou/gopsutil/disk"
-	"github.com/shirou/gopsutil/mem"
 )
 
 var (
@@ -44,8 +40,6 @@ func init() {
 			bufferAcceptByTagPerSec.Init()
 		}
 	}()
-
-	expvar.Publish("system_stats", expvar.Func(SystemInfo))
 }
 
 // IncAcceptedTransactions will increment #accepted transactions for the tag
@@ -104,28 +98,4 @@ func Summary() interface{} {
 	}
 
 	return summary
-}
-
-// SystemInfo returns real-time information about the current system.
-//
-// TODO: Have system information be cross-platform. Linux only for now.
-func SystemInfo() interface{} {
-	c, _ := cpu.Percent(time.Second, true)
-
-	diskDeviceName := "/dev/sda1"
-
-	d, _ := disk.IOCounters(diskDeviceName)
-	v, _ := mem.VirtualMemory()
-
-	systemStats := struct {
-		Memory *mem.VirtualMemoryStat `json:"memory"`
-		CPU    []float64              `json:"cpu"`
-		Disk   disk.IOCountersStat    `json:"disk"`
-	}{
-		CPU:    c,
-		Disk:   d[diskDeviceName],
-		Memory: v,
-	}
-
-	return systemStats
 }


### PR DESCRIPTION
- shouldn't include this in the binary to ship
- if we need system stats, can side load another executable