### PR TITLE
Add flag for log level.

### DIFF
--- a/cmd/wavelet/main.go
+++ b/cmd/wavelet/main.go
@@ -35,7 +35,7 @@ import (
 	"gopkg.in/urfave/cli.v1/altsrc"
 )
 
-// struct to configure how to start the node
+// Config describes how to start the node
 type Config struct {
 	PrivateKeyFile     string
 	Host               string

--- a/log/log.go
+++ b/log/log.go
@@ -33,7 +33,7 @@ func Disable() {
 	logger = zerolog.New(nil).Level(zerolog.Disabled)
 }
 
-// SetLevel sets the log level, accepts one of "off|debug|info|warn|error|fatal|panic"
+// SetLevel sets the log level, accepts one of "off|debug|info|warn|error|fatal"
 func SetLevel(level string) {
 	if l, ok := levelMapping[level]; ok {
 		logger = logger.Level(l)


### PR DESCRIPTION
- currently logging at debug level so load tests are flooded, this flag defaults logging to info
- levels are: `off|debug|info|warn|error|fatal`