### PR TITLE
Supress glog from reporting that flags for 'glog' has not been parsed.

### DIFF
--- a/cmd/wavelet/main.go
+++ b/cmd/wavelet/main.go
@@ -53,7 +53,7 @@ type Config struct {
 
 func main() {
 	// suppress the glog "logging before flag.Parse" error
-	flag.Parse()
+	flag.CommandLine.Parse([]string{})
 
 	app := cli.NewApp()
 


### PR DESCRIPTION
Remove that logging error when the main starts up