### PR TITLE
Clean up sync logs.

### DIFF
--- a/node/plugin.go
+++ b/node/plugin.go
@@ -202,10 +202,7 @@ func (w *Wavelet) Receive(ctx *network.PluginContext) error {
 		var childrenIDs []string
 
 		w.Ledger.Do(func(l *wavelet.Ledger) {
-			children, err := l.Store.GetChildrenBySymbol(msg.Id)
-			if err != nil {
-				log.Error().Err(err).Msg("cannot get children")
-			} else {
+			if children, err := l.Store.GetChildrenBySymbol(msg.Id); err == nil {
 				childrenIDs = children.Transactions
 			}
 		})


### PR DESCRIPTION
remove this log that happens frequently in the load test:
```
{"level":"error","error":"key not found","time":"2018-11-02T15:14:00Z","message":"cannot get children"}
```