### PR TITLE
Always update graph indices on reset.

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -200,7 +200,7 @@ func (g *Graph) lookupTransactionByID(id common.TransactionID) (*Transaction, bo
 
 var (
 	ErrMissingParents = errors.New("parents for transaction are not in graph")
-	ErrAlreadyExists = errors.New("transaction already exists in the graph")
+	ErrAlreadyExists  = errors.New("transaction already exists in the graph")
 )
 
 func (g *Graph) addTransaction(tx Transaction) error {
@@ -376,8 +376,10 @@ func (g *Graph) markTransactionAsComplete(tx *Transaction) error {
 }
 
 func (g *Graph) Reset(newRound *Round) {
-	g.transactions[newRound.Root.ID] = &newRound.Root
-	g.createTransactionIndices(&newRound.Root)
+	ptr := &newRound.Root
+
+	g.transactions[newRound.Root.ID] = ptr
+	g.createTransactionIndices(ptr)
 
 	oldRoot := g.transactions[g.rootID]
 


### PR DESCRIPTION
Graph height was not updated because new root is existing in the graph, so `createTransactionIndices` which does a lot of stuff including updating graph's height is not happening during reset.
And this happens because we already got this transaction from other nodes during sync, but its not yet completed, because we do not have parents for it, so we did not marked it as completed and did not run `createTransactionIndices` in that case either