### PR TITLE
Implement all that is necessary to enable autocomplete for CLI input across ledger data.

### DIFF
--- a/api/mod.go
+++ b/api/mod.go
@@ -201,7 +201,7 @@ func (g *Gateway) Shutdown() {
 func (g *Gateway) sendTransaction(ctx *fasthttp.RequestCtx) {
 	req := new(sendTransactionRequest)
 
-	if g.ledger != nil && g.ledger.TakeSendToken() == false {
+	if g.ledger != nil && g.ledger.TakeSendQuota() == false {
 		g.renderError(ctx, ErrInternal(errors.New("rate limit")))
 		return
 	}

--- a/cmd/wavelet/main.go
+++ b/cmd/wavelet/main.go
@@ -299,13 +299,9 @@ func start(cfg *Config) {
 			Msg("Peer has left.")
 	})
 
-	var kv store.KV = store.NewInmem()
-
-	if len(cfg.Database) > 0 {
-		kv, err = store.NewLevelDB(cfg.Database)
-		if err != nil {
-			logger.Fatal().Err(err).Msgf("Failed to create/open database located at %q.", cfg.Database)
-		}
+	kv, err := store.NewLevelDB(cfg.Database)
+	if err != nil {
+		logger.Fatal().Err(err).Msgf("Failed to create/open database located at %q.", cfg.Database)
 	}
 
 	ledger := wavelet.NewLedger(kv, client, cfg.Genesis)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ replace github.com/go-interpreter/wagon => github.com/perlin-network/wagon v0.3.
 require (
 	github.com/buaazp/fasthttprouter v0.1.1
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+	github.com/dghubble/trie v0.0.0-20190512033633-6d8e3fa705df
 	github.com/fasthttp/websocket v1.4.0
 	github.com/gogo/protobuf v1.2.1
 	github.com/golang/snappy v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dghubble/trie v0.0.0-20190512033633-6d8e3fa705df h1:WRQekGjYIb3oD1ofBVwBa7+0S+2XtUCefOiFCow9/Cw=
+github.com/dghubble/trie v0.0.0-20190512033633-6d8e3fa705df/go.mod h1:P5ymVhkUtwRIkYn2IuBeuVezlrsshMKWQJymph3GOp8=
 github.com/fasthttp/websocket v1.4.0 h1:hWw+gsVLA82cQFDF/vzydHjOedj1Oo00T/uKk+J5kcs=
 github.com/fasthttp/websocket v1.4.0/go.mod h1:4nypHRMj3oQPKA3/LllCXx0F0L5VyVKlMgo3lgbbwBM=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=

--- a/graph.go
+++ b/graph.go
@@ -21,6 +21,7 @@ package wavelet
 
 import (
 	"bytes"
+	"encoding/hex"
 	"github.com/google/btree"
 	"github.com/perlin-network/noise/edwards25519"
 	"github.com/perlin-network/wavelet/sys"
@@ -33,6 +34,10 @@ type GraphOption func(*Graph)
 
 func WithRoot(root Transaction) GraphOption {
 	return func(graph *Graph) {
+		if graph.indexer != nil {
+			graph.indexer.Index(hex.EncodeToString(root.ID[:]))
+		}
+
 		graph.UpdateRoot(root)
 	}
 }
@@ -40,6 +45,12 @@ func WithRoot(root Transaction) GraphOption {
 func WithMetrics(metrics *Metrics) GraphOption {
 	return func(graph *Graph) {
 		graph.metrics = metrics
+	}
+}
+
+func WithIndexer(indexer *Indexer) GraphOption {
+	return func(graph *Graph) {
+		graph.indexer = indexer
 	}
 }
 
@@ -75,6 +86,7 @@ type Graph struct {
 	sync.RWMutex
 
 	metrics *Metrics
+	indexer *Indexer
 
 	transactions map[TransactionID]*Transaction    // All transactions. Includes incomplete transactions.
 	children     map[TransactionID][]TransactionID // Children of transactions. Includes incomplete/missing transactions.
@@ -272,6 +284,10 @@ func (g *Graph) PruneBelowDepth(targetDepth uint64) int {
 
 			g.eligibleIndex.Delete((*sortByDepthTX)(tx))
 			g.seedIndex.Delete((*sortBySeedTX)(tx))
+
+			if g.indexer != nil {
+				g.indexer.Index(hex.EncodeToString(tx.ID[:]))
+			}
 		}
 
 		delete(g.depthIndex, depth)
@@ -548,6 +564,10 @@ func (g *Graph) updateGraph(tx *Transaction) error {
 
 		if complete {
 			delete(g.incomplete, childID)
+
+			if g.indexer != nil {
+				g.indexer.Remove(hex.EncodeToString(tx.ID[:]))
+			}
 
 			if err := g.updateGraph(child); err != nil {
 				continue

--- a/index.go
+++ b/index.go
@@ -1,0 +1,63 @@
+package wavelet
+
+import (
+	"github.com/dghubble/trie"
+	"io"
+	"strings"
+	"sync"
+)
+
+// Indexer indexes all transaction IDs into a single trie for the
+// purposes of suiting the needs of implementing autocomplete
+// related components.
+type Indexer struct {
+	sync.RWMutex
+	index *trie.PathTrie
+}
+
+// NewIndexer instantiates trie indices for indexing complete
+// transactions by their ID.
+func NewIndexer() *Indexer {
+	return &Indexer{index: trie.NewPathTrie()}
+}
+
+// Index indexes a single hex-encoded transaction ID. This
+// method is safe to call concurrently.
+func (m *Indexer) Index(id string) {
+	m.Lock()
+	m.index.Put(id, struct{}{})
+	m.Unlock()
+}
+
+// Remove un-indexes a single hex-encoded transaction ID. This
+// method is safe to call concurrently.
+func (m *Indexer) Remove(id string) {
+	m.Lock()
+	m.index.Delete(id)
+	m.Unlock()
+}
+
+// Find searches through complete transaction indices for a specified
+// query string. All indices that queried are in the form of tries.
+func (m *Indexer) Find(query string, count int) []string {
+	results := make([]string, 0, count)
+
+	m.RLock()
+	defer m.RUnlock()
+
+	_ = m.index.Walk(func(key string, _ interface{}) error {
+		if len(results) >= count {
+			return io.EOF
+		}
+
+		if !strings.HasPrefix(key, query) {
+			return io.EOF
+		}
+
+		results = append(results, key)
+
+		return nil
+	})
+
+	return results
+}

--- a/ledger.go
+++ b/ledger.go
@@ -45,6 +45,7 @@ import (
 type Ledger struct {
 	client  *skademlia.Client
 	metrics *Metrics
+	indexer *Indexer
 
 	accounts *Accounts
 	rounds   *Rounds
@@ -67,11 +68,12 @@ type Ledger struct {
 	cacheCollapse *LRU
 	cacheChunks   *LRU
 
-	sendQuotaTokenBucket chan struct{}
+	sendQuota chan struct{}
 }
 
 func NewLedger(kv store.KV, client *skademlia.Client, genesis *string) *Ledger {
 	metrics := NewMetrics(context.TODO())
+	indexer := NewIndexer()
 
 	accounts := NewAccounts(kv)
 	go accounts.GC(context.Background())
@@ -101,7 +103,7 @@ func NewLedger(kv store.KV, client *skademlia.Client, genesis *string) *Ledger {
 		panic("???: COULD NOT FIND GENESIS, OR STORAGE IS CORRUPTED.")
 	}
 
-	graph := NewGraph(WithMetrics(metrics), WithRoot(round.End), VerifySignatures())
+	graph := NewGraph(WithMetrics(metrics), WithIndexer(indexer), WithRoot(round.End), VerifySignatures())
 
 	gossiper := NewGossiper(context.TODO(), client, metrics)
 	finalizer := NewSnowball(WithBeta(sys.SnowballBeta))
@@ -110,6 +112,7 @@ func NewLedger(kv store.KV, client *skademlia.Client, genesis *string) *Ledger {
 	ledger := &Ledger{
 		client:  client,
 		metrics: metrics,
+		indexer: indexer,
 
 		accounts: accounts,
 		rounds:   rounds,
@@ -126,32 +129,14 @@ func NewLedger(kv store.KV, client *skademlia.Client, genesis *string) *Ledger {
 		cacheCollapse: NewLRU(16),
 		cacheChunks:   NewLRU(1024), // In total, it will take up 1024 * 4MB.
 
-		sendQuotaTokenBucket: make(chan struct{}, 2000),
+		sendQuota: make(chan struct{}, 2000),
 	}
 
 	go ledger.SyncToLatestRound()
 	go ledger.PerformConsensus()
-	go ledger.FeedSendTokenIntoBucket()
+	go ledger.PushSendQuota()
 
 	return ledger
-}
-
-func (l *Ledger) FeedSendTokenIntoBucket() {
-	for range time.Tick(1 * time.Millisecond) {
-		select {
-		case l.sendQuotaTokenBucket <- struct{}{}:
-		default:
-		}
-	}
-}
-
-func (l *Ledger) TakeSendToken() bool {
-	select {
-	case <-l.sendQuotaTokenBucket:
-		return true
-	default:
-		return false
-	}
 }
 
 // AddTransaction adds a transaction to the ledger. If the transaction has
@@ -168,7 +153,7 @@ func (l *Ledger) AddTransaction(tx Transaction) error {
 	}
 
 	if err == nil {
-		l.TakeSendToken()
+		l.TakeSendQuota()
 
 		l.gossiper.Push(tx)
 
@@ -184,6 +169,65 @@ func (l *Ledger) AddTransaction(tx Transaction) error {
 	}
 
 	return nil
+}
+
+// Find searches through complete transaction and account indices for a specified
+// query string. All indices that queried are in the form of tries. It is safe
+// to call this method concurrently.
+func (l *Ledger) Find(query string, count int) []string {
+	var err error
+
+	results := make([]string, 0, count)
+	prefix := []byte(query)
+
+	if len(query)%2 == 1 { // Cut off a single character.
+		prefix = prefix[:len(prefix)-1]
+	}
+
+	prefix, err = hex.DecodeString(string(prefix))
+	if err != nil {
+		return nil
+	}
+
+	bucketPrefix := append(keyAccounts[:], keyAccountNonce[:]...)
+	fullQuery := append(bucketPrefix, prefix...)
+
+	l.Snapshot().IterateFrom(fullQuery, func(key, _ []byte) bool {
+		if !bytes.HasPrefix(key, fullQuery) {
+			return false
+		}
+
+		if len(results) >= count {
+			return false
+		}
+
+		results = append(results, hex.EncodeToString(key[len(bucketPrefix):]))
+		return true
+	})
+
+	return append(results, l.indexer.Find(query, count-len(results))...)
+}
+
+// PushSendQuota permits one token into this nodes send quota bucket every millisecond
+// such that the node may add one single transaction into its graph.
+func (l *Ledger) PushSendQuota() {
+	for range time.Tick(1 * time.Millisecond) {
+		select {
+		case l.sendQuota <- struct{}{}:
+		default:
+		}
+	}
+}
+
+// TakeSendQuota removes one token from this nodes send quota bucket to signal
+// that the node has added one single transaction into its graph.
+func (l *Ledger) TakeSendQuota() bool {
+	select {
+	case <-l.sendQuota:
+		return true
+	default:
+		return false
+	}
 }
 
 // Protocol returns an implementation of WaveletServer to handle incoming

--- a/store/leveldb.go
+++ b/store/leveldb.go
@@ -24,6 +24,7 @@ import (
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/filter"
 	"github.com/syndtr/goleveldb/leveldb/opt"
+	"github.com/syndtr/goleveldb/leveldb/storage"
 )
 
 var _ WriteBatch = (*leveldbWriteBatch)(nil)
@@ -107,9 +108,19 @@ func NewLevelDB(dir string) (*leveldbKV, error) {
 		NoWriteMerge: true,
 	}
 
-	db, err := leveldb.OpenFile(dir, opts)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create Level DB")
+	var db *leveldb.DB
+	var err error
+
+	if len(dir) == 0 {
+		db, err = leveldb.Open(storage.NewMemStorage(), opts)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to init leveldb")
+		}
+	} else {
+		db, err = leveldb.OpenFile(dir, opts)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to init leveldb")
+		}
 	}
 
 	return &leveldbKV{


### PR DESCRIPTION
graph, ledger, index: index completed transactions by their ids concurrently, create a Find() method that searches through both AVL tree and trie indices for account/smart contract/transaction ids
ledger, api: rename and document send quota token bucket-related methods for rate limiting a nodes ability to create transactions
store, cmd/wavelet: make wavelet by default use leveldbs in-memory database rather than an in-memory skiplist as a database
mod: add dependency on github.com/dghubble/trie