### PR TITLE
Fix logged event type for rejected transactions.

### DIFF
--- a/ledger.go
+++ b/ledger.go
@@ -1212,7 +1212,7 @@ func (l *Ledger) CollapseTransactions(round uint64, root Transaction, end Transa
 			}
 
 			for i, tx := range res.rejected {
-				logEventTX("failed", tx, res.rejectedErrors[i])
+				logEventTX("rejected", tx, res.rejectedErrors[i])
 			}
 		}
 	}()


### PR DESCRIPTION
This affects wavelet-client and Lens which are listening for "rejected" when Wavelet was sending out  "failed" events.