### PR TITLE
Fix a minor bug in cmd/graph flag arguments.

### DIFF
--- a/cmd/graph/main.go
+++ b/cmd/graph/main.go
@@ -128,8 +128,8 @@ func main() {
 		go api.New().StartHTTP(*apiPortFlag, client, ledger, keys)
 	}
 
-	if len(flag.Args()) > 1 {
-		for _, addr := range flag.Args()[1:] {
+	if len(flag.Args()) > 0 {
+		for _, addr := range flag.Args()[:] {
 			if _, err := client.Dial(addr); err != nil {
 				fmt.Printf("Error dialing %s: %v\n", addr, err)
 			}


### PR DESCRIPTION
The bug is that the bootstrap peers flag arguments skip the first peer argument. It should start with 0 instead of 1.