### PR TITLE
Ledger state syncing / pull missing transactions - minor cleanup and improvements.

### DIFF
--- a/gossip.go
+++ b/gossip.go
@@ -65,42 +65,19 @@ func (g *Gossiper) Push(tx Transaction) {
 }
 
 func (g *Gossiper) Gossip(transactions [][]byte) {
-	//var err error
-
 	batch := &Transactions{Transactions: transactions}
 
 	peers := g.client.ClosestPeers()
 
 	var wg sync.WaitGroup
 	for _, p := range peers {
-		//if p.GetState() != connectivity.Ready {
-		//	continue
-		//}
-		//target := conn.Target()
 		client := NewWaveletClient(p)
 
 		ctx, _ := context.WithTimeout(context.Background(), 100 * time.Millisecond)
 		stream, err := client.Gossip(ctx)
 		if err != nil {
-			//fmt.Println("gossiping error", err)
-			//g.streamsLock.Unlock()
 			continue
 		}
-		//g.streamsLock.Lock()
-		//stream, exists := g.streams[conn.Target()]
-		//
-		//if !exists {
-		//	client := NewWaveletClient(conn)
-		//
-		//	ctx, _ := context.WithTimeout(context.Background(), 100 * time.Millisecond)
-		//	if stream, err = client.Gossip(ctx); err != nil {
-		//		g.streamsLock.Unlock()
-		//		continue
-		//	}
-		//
-		//	g.streams[target] = stream
-		//}
-		//g.streamsLock.Unlock()
 
 		wg.Add(1)
 
@@ -108,10 +85,6 @@ func (g *Gossiper) Gossip(transactions [][]byte) {
 			if err := stream.Send(batch); err != nil {
 				logger := log.TX("gossip")
 				logger.Err(err).Msg("Failed to send batch")
-
-				//g.streamsLock.Lock()
-				//delete(g.streams, target)
-				//g.streamsLock.Unlock()
 			}
 
 			wg.Done()

--- a/gossip.go
+++ b/gossip.go
@@ -82,12 +82,15 @@ func (g *Gossiper) Gossip(transactions [][]byte) {
 		wg.Add(1)
 
 		go func() {
+			defer func() {
+				_ = stream.CloseSend()
+				wg.Done()
+			}()
+
 			if err := stream.Send(batch); err != nil {
 				logger := log.TX("gossip")
 				logger.Err(err).Msg("Failed to send batch")
 			}
-
-			wg.Done()
 		}()
 	}
 

--- a/ledger.go
+++ b/ledger.go
@@ -485,7 +485,7 @@ FINALIZE_ROUNDS:
 		go CollectVotes(l.accounts, l.finalizer, voteChan, &workerWG)
 
 		req := &QueryRequest{RoundIndex: current.Index + 1}
-
+		t := time.Now()
 		for i := 0; i < cap(workerChan); i++ {
 			go func() {
 				for conn := range workerChan {
@@ -616,7 +616,7 @@ FINALIZE_ROUNDS:
 				workerChan <- peer
 			}
 		}
-
+		fmt.Println("Time consensus took -", time.Now().Sub(t))
 		close(workerChan)
 		workerWG.Wait() // Wait for query workers to close.
 		workerWG.Add(1)

--- a/snowball.go
+++ b/snowball.go
@@ -32,6 +32,12 @@ func WithBeta(beta int) SnowballOption {
 	}
 }
 
+func WithName(name string) SnowballOption {
+	return func(snowball *Snowball) {
+		snowball.name = name
+	}
+}
+
 const (
 	SnowballDefaultBeta = 150
 )
@@ -46,6 +52,7 @@ type Snowball struct {
 	counts  map[RoundID]int
 	count   int
 	decided bool
+	name string
 }
 
 func NewSnowball(opts ...SnowballOption) *Snowball {
@@ -53,6 +60,7 @@ func NewSnowball(opts ...SnowballOption) *Snowball {
 		beta:       SnowballDefaultBeta,
 		candidates: make(map[RoundID]*Round),
 		counts:     make(map[RoundID]int),
+		name: "default",
 	}
 
 	for _, opt := range opts {
@@ -104,7 +112,7 @@ func (s *Snowball) Tick(round *Round) {
 
 	if s.lastID != round.ID { // Handle termination case.
 		if s.lastID != ZeroRoundID {
-			fmt.Printf("Snowball liveness fault: Last ID is %x with count %d, and new ID is %x.\n", s.lastID, s.count, round.ID)
+			fmt.Printf("Snowball (%s) liveness fault: Last ID is %x with count %d, and new ID is %x.\n", s.name, s.lastID, s.count, round.ID)
 		}
 
 		s.lastID = round.ID

--- a/sys/const.go
+++ b/sys/const.go
@@ -53,7 +53,7 @@ var (
 	QueryTimeout = 1 * time.Second
 
 	// Number of rounds we should be behind before we start syncing.
-	SyncIfRoundsDifferBy uint64 = 5
+	SyncIfRoundsDifferBy uint64 = 2
 
 	// Size of individual chunks sent for a syncing peer.
 	SyncChunkSize = 16384

--- a/sys/const.go
+++ b/sys/const.go
@@ -45,7 +45,7 @@ var (
 	SKademliaC2 = 1
 
 	// Snowball consensus protocol parameters.
-	SnowballK     = 2
+	SnowballK     = 5
 	SnowballAlpha = 0.8
 	SnowballBeta  = 150
 

--- a/sys/const.go
+++ b/sys/const.go
@@ -53,7 +53,7 @@ var (
 	QueryTimeout = 1 * time.Second
 
 	// Number of rounds we should be behind before we start syncing.
-	SyncIfRoundsDifferBy uint64 = 2
+	SyncIfRoundsDifferBy uint64 = 5
 
 	// Size of individual chunks sent for a syncing peer.
 	SyncChunkSize = 16384

--- a/vote.go
+++ b/vote.go
@@ -48,21 +48,21 @@ func CollectVotes(accounts *Accounts, snowball *Snowball, voteChan <-chan vote, 
 			stakes := make(map[AccountID]float64, len(votes))
 			maxStake := float64(0)
 
-			for _, vote := range votes {
+			for i, vote := range votes {
 				if vote.preferred == nil {
-					vote.preferred = ZeroRoundPtr
+					votes[i].preferred = ZeroRoundPtr
 				}
 
-				stake, _ := ReadAccountStake(snapshot, vote.voter.PublicKey())
-
-				if stake < sys.MinimumStake {
-					stake = sys.MinimumStake
+				s, _ := ReadAccountStake(snapshot, vote.voter.PublicKey())
+				if s < sys.MinimumStake {
+					s = sys.MinimumStake
 				}
 
-				stakes[vote.voter.PublicKey()] = float64(stake)
+				stake := float64(s)
+				stakes[vote.voter.PublicKey()] = stake
 
-				if maxStake < stakes[vote.voter.PublicKey()] {
-					maxStake = stakes[vote.voter.PublicKey()]
+				if maxStake < stake {
+					maxStake = stake
 				}
 			}
 
@@ -70,10 +70,6 @@ func CollectVotes(accounts *Accounts, snowball *Snowball, voteChan <-chan vote, 
 			totalCount := float64(0)
 
 			for _, vote := range votes {
-				if vote.preferred == nil {
-					vote.preferred = ZeroRoundPtr
-				}
-
 				count := stakes[vote.voter.PublicKey()] / maxStake
 				counts[vote.preferred.ID] += count
 				totalCount += count
@@ -82,10 +78,6 @@ func CollectVotes(accounts *Accounts, snowball *Snowball, voteChan <-chan vote, 
 			var majority *Round
 
 			for _, vote := range votes {
-				if vote.preferred == nil {
-					vote.preferred = ZeroRoundPtr
-				}
-
 				if counts[vote.preferred.ID]/totalCount >= sys.SnowballAlpha {
 					majority = vote.preferred
 					break


### PR DESCRIPTION
Stop pulling missing transactions in case state sync needs to be done immediately instead of waiting for now more missing transaction
Lower most of syncing related timeouts - pulling, querying etc
Add check for live connections in most places - before pulling and for `SelectPeers`
Change how gossip network part works - do not store streams, create new stream each time instead and just pass in case of error - it avoid problem using "dead" connection and connection which were not removed from map. And since we send transactions in batch overhead of creating new connection is not that big.