### PR TITLE
Fix committing an AVL tree with a nil root.

### DIFF
--- a/avl/tree.go
+++ b/avl/tree.go
@@ -175,8 +175,13 @@ func (t *Tree) doPrintContents(n *node, depth int) {
 
 func (t *Tree) Commit() error {
 	if t.root == nil {
+		// Tree is empty, so just delete the root.
+		// If deleting the root fails because it doesn't exist, ignore the error.
+		_ = t.kv.Delete(RootKey)
+
 		return nil
 	}
+
 	batch := t.kv.NewWriteBatch()
 
 	err := t.root.dfs(t, false, func(n *node) (bool, error) {
@@ -210,14 +215,7 @@ func (t *Tree) Commit() error {
 		}
 	}
 
-	if t.root != nil {
-		return t.kv.Put(RootKey, t.root.id[:])
-	}
-
-	// If deleting the root fails because it doesn't exist, ignore the error.
-	_ = t.kv.Delete(RootKey)
-
-	return nil
+	return t.kv.Put(RootKey, t.root.id[:])
 }
 
 func (t *Tree) getNextOldRootIndex() uint64 {


### PR DESCRIPTION
This fixes a bug where if all of the tree nodes are removed (causing `root` to be `nil`), the changes will not be committed.