### PR TITLE
cmd/wavelet: fix unspecified wallet flag not generating random wallet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
         - "1.12.5"
       install: true
       script:
+        - GO111MODULE=on go build -o $GOPATH/bin/wavelet ./cmd/wavelet
         - GO111MODULE=on go test -coverprofile=coverage.txt -covermode=atomic -bench -race ./...
       after_success:
         - bash <(curl -s https://codecov.io/bash)

--- a/cmd/wavelet/main.go
+++ b/cmd/wavelet/main.go
@@ -98,7 +98,6 @@ func main() {
 		}),
 		altsrc.NewStringFlag(cli.StringFlag{
 			Name:   "wallet",
-			Value:  "config/wallet.txt",
 			Usage:  "Path to file containing hex-encoded private key. If the path specified is invalid, or no file exists at the specified path, a random wallet will be generated. Optionally, a 128-length hex-encoded private key to a wallet may also be specified.",
 			EnvVar: "WAVELET_WALLET",
 		}),

--- a/cmd/wavelet/main_test.go
+++ b/cmd/wavelet/main_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var wallet1 = "87a6813c3b4cf534b6ae82db9b1409fa7dbd5c13dba5858970b56084c4a930eb400056ee68a7cc2695222df05ea76875bc27ec6e61e8e62317c336157019c405"
+var wallet2 = "85e7450f7cf0d9cd1d1d7bf4169c2f364eea4ba833a7280e0f931a1d92fd92c2696937c2c8df35dba0169de72990b80761e51dd9e2411fa1fce147f68ade830a"
+var wallet3 = "5b9fcd2d6f8e34f4aa472e0c3099fefd25f0ceab9e908196b1dda63e55349d22f03bb6f98c4dfd31f3d448c7ec79fa3eaa92250112ada43471812f4b1ace6467"
+
+func TestWavelet_Default(t *testing.T) {
+	wavelet := New(t, nil)
+	defer wavelet.Stop()
+
+	ledger := wavelet.GetLedgerStatus(t)
+	// Make sure a random wallet is generated
+	assert.NotEqual(t, wallet1, ledger.PublicKey)
+	assert.NotEqual(t, wallet2, ledger.PublicKey)
+	assert.NotEqual(t, wallet3, ledger.PublicKey)
+}
+
+func TestWavelet_InvalidWallet(t *testing.T) {
+	wavelet := New(t, func(cfg *Config) {
+		cfg.Wallet = "foobar"
+	})
+	defer wavelet.Stop()
+
+	ledger := wavelet.GetLedgerStatus(t)
+	// If specified wallet is not a valid private key,
+	// a random wallet is also generated
+	assert.NotEqual(t, wallet1, ledger.PublicKey)
+	assert.NotEqual(t, wallet2, ledger.PublicKey)
+	assert.NotEqual(t, wallet3, ledger.PublicKey)
+}
+
+func TestWavelet_WithWalletString(t *testing.T) {
+	wavelet := New(t, func(cfg *Config) {
+		cfg.Wallet = wallet2
+	})
+	defer wavelet.Stop()
+
+	ledger := wavelet.GetLedgerStatus(t)
+	assert.Equal(t, wallet2[64:], ledger.PublicKey)
+}
+
+func TestWavelet_WithWalletPath(t *testing.T) {
+	// Write wallet3 to a temporary file
+	dir, err := ioutil.TempDir("", "wavelet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	walletPath := filepath.Join(dir, "wallet3.txt")
+	if err := ioutil.WriteFile(walletPath, []byte(wallet3), 0666); err != nil {
+		t.Fatal(err)
+	}
+
+	wavelet := New(t, func(cfg *Config) {
+		cfg.Wallet = walletPath
+	})
+	defer wavelet.Stop()
+
+	ledger := wavelet.GetLedgerStatus(t)
+	assert.Equal(t, wallet3[64:], ledger.PublicKey)
+}

--- a/cmd/wavelet/wavelet_test.go
+++ b/cmd/wavelet/wavelet_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+	"github.com/phayes/freeport"
+)
+
+type TestWavelet struct {
+	cmd    *exec.Cmd
+	pty    *os.File
+	config *Config
+}
+
+type TestLedgerStatus struct {
+	PublicKey string `json:"public_key"`
+	Address   string `json:"address"`
+}
+
+// New starts a Wavelet process.
+func New(t *testing.T, cb func(cfg *Config)) *TestWavelet {
+	path, err := exec.LookPath("wavelet")
+	if err != nil || path == "" {
+		t.Fatal("wavelet not found on $PATH")
+	}
+
+	cfg := defaultTestConfig(t)
+	if cb != nil {
+		cb(cfg)
+	}
+
+	args := []string{}
+
+	if cfg.Port > 0 {
+		args = append(args, []string{"--port", fmt.Sprintf("%d", cfg.Port)}...)
+	}
+	if cfg.APIPort > 0 {
+		args = append(args, []string{"--api.port", fmt.Sprintf("%d", cfg.APIPort)}...)
+	}
+	if cfg.Wallet != "" {
+		args = append(args, []string{"--wallet", cfg.Wallet}...)
+	}
+
+	cmd := exec.Command("wavelet", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// Use pty to force the process to run in interactive mode.
+	// Otherwise, the process will immediately exit because stdin
+	// will immediately return io.EOF.
+	pty, err := pty.Start(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wavelet := &TestWavelet{cmd: cmd, pty: pty, config: cfg}
+
+	// Make sure Wavelet starts successfully by checking the API
+	if err := wavelet.waitForAPI(t); err != nil {
+		defer wavelet.Stop()
+		t.Fatal(err)
+	}
+
+	return wavelet
+}
+
+func defaultTestConfig(t *testing.T) *Config {
+	return &Config{
+		Port:    nextPort(t),
+		APIPort: nextPort(t),
+		Wallet:  "",
+	}
+}
+
+func nextPort(t *testing.T) uint {
+	port, err := freeport.GetFreePort()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return uint(port)
+}
+
+func (w *TestWavelet) waitForAPI(t *testing.T) error {
+	timeout := time.After(3 * time.Second)
+	tick := time.Tick(1 * time.Second)
+
+	var lastErr error
+	for {
+		select {
+		case <-timeout:
+			return lastErr
+
+		case <-tick:
+			if _, err := w.getLedgerStatus(); err != nil {
+				lastErr = err
+				break
+			}
+
+			return nil
+		}
+	}
+}
+
+// Stop interrupts the Wavelet process and waits for it to shutdown.
+func (w *TestWavelet) Stop() error {
+	if w.cmd == nil {
+		return nil
+	}
+
+	if w.cmd.Process != nil {
+		if err := w.cmd.Process.Signal(os.Interrupt); err != nil {
+			return err
+		}
+	}
+
+	return w.cmd.Wait()
+}
+
+// GetLedgerStatus returns the ledger status.
+func (w *TestWavelet) GetLedgerStatus(t *testing.T) *TestLedgerStatus {
+	ledger, err := w.getLedgerStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return ledger
+}
+
+func (w *TestWavelet) getLedgerStatus() (*TestLedgerStatus, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%d/ledger", w.config.APIPort), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
+	defer cancel()
+
+	req = req.WithContext(ctx)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("expecting GET /ledger to return 200, got %d instead", resp.StatusCode)
+	}
+
+	var ledger TestLedgerStatus
+	if err := json.NewDecoder(resp.Body).Decode(&ledger); err != nil {
+		return nil, err
+	}
+
+	return &ledger, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/buaazp/fasthttprouter v0.1.1
 	github.com/chzyer/logex v1.1.10 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+	github.com/creack/pty v1.1.7
 	github.com/dghubble/trie v0.0.0-20190512033633-6d8e3fa705df
 	github.com/fasthttp/websocket v1.4.0
 	github.com/gogo/protobuf v1.2.1
@@ -16,6 +17,7 @@ require (
 	github.com/huandu/skiplist v0.0.0-20180112095830-8e883b265e1b
 	github.com/perlin-network/life v0.0.0-20190521143330-57f3819c2df0
 	github.com/perlin-network/noise v0.0.0-20190527211417-79abfb78fdba
+	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d
 	github.com/pkg/errors v0.8.1
 	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWs
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/creack/pty v1.1.7 h1:6pwm8kMQKCmgUg0ZHTm5+/YvRK0s3THD/28+T6/kk4A=
+github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dghubble/trie v0.0.0-20190512033633-6d8e3fa705df h1:WRQekGjYIb3oD1ofBVwBa7+0S+2XtUCefOiFCow9/Cw=
@@ -57,6 +59,8 @@ github.com/perlin-network/noise v0.0.0-20190527211417-79abfb78fdba h1:SZX6pHLS2v
 github.com/perlin-network/noise v0.0.0-20190527211417-79abfb78fdba/go.mod h1:1Ca3rEoDZseet9F06+H47KpsOr+ZgpbbJO7Dg9WC4lM=
 github.com/perlin-network/wagon v0.3.1-0.20180825141017-f8cb99b55a39 h1:CYHXy6CWxxL7ugjvCbTELOm2j5iRLEWGPl3AQYvretw=
 github.com/perlin-network/wagon v0.3.1-0.20180825141017-f8cb99b55a39/go.mod h1:zHOMvbitcZek8oshsMO5VpyBjWjV9X8cn8WTZwdebpM=
+github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 h1:JhzVVoYvbOACxoUmOs6V/G4D5nPVUW73rKvXxP4XUJc=
+github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d h1:U+PMnTlV2tu7RuMK5etusZG3Cf+rpow5hqQByeCzJ2g=
 github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d/go.mod h1:lXfE4PvvTW5xOjO6Mba8zDPyw8M93B6AQ7frTGnMlA8=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=


### PR DESCRIPTION
The documentation states that by not specifying the `--wallet` flag, a new wallet will be [randomly generated](https://wavelet.perlin.net/docs/setup#wallet-management). But currently, not specifying the `--wallet` flag will make Wavelet use `config/wavelet.txt` as the wallet. In order to to generate a random wallet, the `--wallet` flag has to be explicitly set to empty, e.g.:

```sh
$ ./wavelet --port 3000 --api.port 9000 --wallet ""
```

This PR fixes this bug, so that not specifying the `--wallet` flag will generate a random wallet. It also adds integration tests for `cmd/wavelet`. It requires `wavelet` binary to be in `$PATH`, so you need to install it if you want to run the test locally:

```sh
$ go install ./cmd/wavelet
```