### PR TITLE
Prefer values over heap-allocated values, simplify memory model, and fix appending parent transaction seeds to transactions.

### DIFF
--- a/api/mod.go
+++ b/api/mod.go
@@ -220,7 +220,7 @@ func (g *Gateway) sendTransaction(ctx *fasthttp.RequestCtx) {
 
 	tx := wavelet.AttachSenderToTransaction(
 		g.keys,
-		&wavelet.Transaction{Tag: sys.Tag(req.Tag), Payload: req.payload, Creator: req.creator, CreatorSignature: req.signature},
+		wavelet.Transaction{Tag: sys.Tag(req.Tag), Payload: req.payload, Creator: req.creator, CreatorSignature: req.signature},
 		g.ledger.Graph().FindEligibleParents()...,
 	)
 
@@ -231,7 +231,7 @@ func (g *Gateway) sendTransaction(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	g.render(ctx, &sendTransactionResponse{ledger: g.ledger, tx: tx})
+	g.render(ctx, &sendTransactionResponse{ledger: g.ledger, tx: &tx})
 }
 
 func (g *Gateway) ledgerStatus(ctx *fasthttp.RequestCtx) {

--- a/cmd/wavelet/shell.go
+++ b/cmd/wavelet/shell.go
@@ -591,7 +591,7 @@ func (cli *CLI) withdrawReward(cmd []string) {
 		Msgf("Success! Your reward withdrawal transaction ID: %x", tx.ID)
 }
 
-func (cli *CLI) sendTransaction(tx *wavelet.Transaction) (*wavelet.Transaction, error) {
+func (cli *CLI) sendTransaction(tx wavelet.Transaction) (wavelet.Transaction, error) {
 	tx = wavelet.AttachSenderToTransaction(cli.keys, tx, cli.ledger.Graph().FindEligibleParents()...)
 
 	if err := cli.ledger.AddTransaction(tx); err != nil && errors.Cause(err) != wavelet.ErrMissingParents {

--- a/collapse.go
+++ b/collapse.go
@@ -23,6 +23,13 @@ func processRewardWithdrawals(round uint64, snapshot *avl.Tree) {
 	}
 }
 
+// rewardValidators deducts a transaction fee from a transactions creator, and transfers the fee
+// to a rewardee which is determined by a validator reward scheme given the selected ancestry
+// of the transaction.
+//
+// If no rewardee is selected, then the transaction fee is simply burned. A reference to
+// a transaction is expected when calling this function to prevent any additional requirements
+// of looking up said transaction within the graph.
 func rewardValidators(g *Graph, snapshot *avl.Tree, tx *Transaction, logging bool) error {
 	fee := sys.TransactionFeeAmount
 

--- a/genesis.go
+++ b/genesis.go
@@ -152,8 +152,8 @@ func performInception(tree *avl.Tree, genesis *string) Round {
 		logger.Fatal().Err(err).Msg("accounts.Visit")
 	}
 
-	tx := &Transaction{}
+	tx := Transaction{}
 	tx.rehash()
 
-	return NewRound(0, tree.Checksum(), 0, &Transaction{}, tx)
+	return NewRound(0, tree.Checksum(), 0, Transaction{}, tx)
 }

--- a/gossip.go
+++ b/gossip.go
@@ -56,7 +56,7 @@ func NewGossiper(ctx context.Context, client *skademlia.Client, metrics *Metrics
 	return g
 }
 
-func (g *Gossiper) Push(tx *Transaction) {
+func (g *Gossiper) Push(tx Transaction) {
 	g.debouncer.Add(debounce.Bytes(tx.Marshal()))
 
 	if g.metrics != nil {
@@ -73,7 +73,7 @@ func (g *Gossiper) Gossip(transactions [][]byte) {
 	for _, p := range peers {
 		client := NewWaveletClient(p)
 
-		ctx, _ := context.WithTimeout(context.Background(), 100 * time.Millisecond)
+		ctx, _ := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		stream, err := client.Gossip(ctx)
 		if err != nil {
 			continue

--- a/round.go
+++ b/round.go
@@ -40,11 +40,11 @@ type Round struct {
 
 	Applied uint64
 
-	Start *Transaction
-	End   *Transaction
+	Start Transaction
+	End   Transaction
 }
 
-func NewRound(index uint64, merkle MerkleNodeID, applied uint64, start, end *Transaction) Round {
+func NewRound(index uint64, merkle MerkleNodeID, applied uint64, start, end Transaction) Round {
 	r := Round{
 		Index:   index,
 		Merkle:  merkle,

--- a/rounds_test.go
+++ b/rounds_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func TestNewRounds(t *testing.T) {
+	t.Parallel()
+
 	storage := store.NewInmem()
 
 	rm, err := NewRounds(storage, 10)
@@ -41,8 +43,8 @@ func TestNewRounds(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		r := &Round{
 			Index: uint64(i + 1),
-			Start: &Transaction{},
-			End:   &Transaction{},
+			Start: Transaction{},
+			End:   Transaction{},
 		}
 		_, err := rm.Save(r)
 		assert.NoError(t, err)
@@ -66,6 +68,8 @@ func TestNewRounds(t *testing.T) {
 }
 
 func TestRoundsCircular(t *testing.T) {
+	t.Parallel()
+
 	storage := store.NewInmem()
 
 	rm, err := NewRounds(storage, 10)
@@ -80,8 +84,8 @@ func TestRoundsCircular(t *testing.T) {
 	for i := 0; i < 15; i++ {
 		r := &Round{
 			Index: uint64(i + 1),
-			Start: &Transaction{},
-			End:   &Transaction{},
+			Start: Transaction{},
+			End:   Transaction{},
 		}
 		_, err := rm.Save(r)
 		assert.NoError(t, err)

--- a/snowball.go
+++ b/snowball.go
@@ -52,7 +52,7 @@ type Snowball struct {
 	counts  map[RoundID]int
 	count   int
 	decided bool
-	name string
+	name    string
 }
 
 func NewSnowball(opts ...SnowballOption) *Snowball {
@@ -60,7 +60,7 @@ func NewSnowball(opts ...SnowballOption) *Snowball {
 		beta:       SnowballDefaultBeta,
 		candidates: make(map[RoundID]*Round),
 		counts:     make(map[RoundID]int),
-		name: "default",
+		name:       "default",
 	}
 
 	for _, opt := range opts {

--- a/sys/const.go
+++ b/sys/const.go
@@ -45,7 +45,7 @@ var (
 	SKademliaC2 = 1
 
 	// Snowball consensus protocol parameters.
-	SnowballK     = 5
+	SnowballK     = 2
 	SnowballAlpha = 0.8
 	SnowballBeta  = 150
 

--- a/tx.go
+++ b/tx.go
@@ -124,7 +124,7 @@ func AttachSenderToTransaction(sender *skademlia.Keypair, tx Transaction, parent
 	return tx
 }
 
-func (tx *Transaction) rehash() *Transaction {
+func (tx *Transaction) rehash() {
 	logger := log.Node()
 
 	tx.ID = blake2b.Sum256(tx.Marshal())
@@ -158,8 +158,6 @@ func (tx *Transaction) rehash() *Transaction {
 	copy(tx.Seed[:], seed)
 
 	tx.SeedLen = byte(prefixLen(seed))
-
-	return tx
 }
 
 func (tx Transaction) Marshal() []byte {

--- a/tx_json_test.go
+++ b/tx_json_test.go
@@ -8,6 +8,8 @@ import (
 
 // TestParseJSON tests the functionality of the ParseJSON helper method.
 func TestParseJSON(t *testing.T) {
+	t.Parallel()
+
 	f := func(jsonData []byte, tag string) bool {
 		payload, err := ParseJSON(jsonData, tag) // Attempt to parse
 		return !(err != nil && payload != nil)   // Check errored but still returned


### PR DESCRIPTION
api, cmd/wavelet, gossip, collapse, genesis, ledger, round: revert to original memory alloc model such that values are emphasized over pointers to ensure correctness
tx: fix AttachSenderToTransaction to properly sort and index parent seeds with respect to index locations of parent ids
tests: parallelize tests where possible