### PR TITLE
graph: fix validateTransaction skipping a parent

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -22,12 +22,13 @@ package wavelet
 import (
 	"bytes"
 	"encoding/hex"
+	"sort"
+	"sync"
+
 	"github.com/google/btree"
 	"github.com/perlin-network/noise/edwards25519"
 	"github.com/perlin-network/wavelet/sys"
 	"github.com/pkg/errors"
-	"sort"
-	"sync"
 )
 
 type GraphOption func(*Graph)
@@ -636,12 +637,12 @@ func (g *Graph) validateTransaction(tx Transaction) error {
 	// Check that parents are lexicographically sorted, are not itself, and are unique.
 	set := make(map[TransactionID]struct{}, len(tx.ParentIDs))
 
-	for i := len(tx.ParentIDs) - 1; i > 0; i-- {
+	for i := len(tx.ParentIDs) - 1; i >= 0; i-- {
 		if tx.ID == tx.ParentIDs[i] {
 			return errors.New("tx must not include itself in its parents")
 		}
 
-		if bytes.Compare(tx.ParentIDs[i-1][:], tx.ParentIDs[i][:]) > 0 {
+		if i > 0 && bytes.Compare(tx.ParentIDs[i-1][:], tx.ParentIDs[i][:]) > 0 {
 			return errors.New("tx must have lexicographically sorted parent ids")
 		}
 


### PR DESCRIPTION
`Graph.validateTransaction` accidentally skips checking if `ParentIDs[0]` is a duplicate transaction, or the transaction itself.