### PR TITLE
utils: fix failing TestSelectPeers

### DIFF
--- a/store/inmem.go
+++ b/store/inmem.go
@@ -21,9 +21,10 @@ package store
 
 import (
 	"bytes"
+	"sync"
+
 	"github.com/huandu/skiplist"
 	"github.com/pkg/errors"
-	"sync"
 )
 
 type kvPair struct {
@@ -60,6 +61,14 @@ type inmemKV struct {
 }
 
 func (s *inmemKV) Close() error {
+	s.Lock()
+	defer s.Unlock()
+
+	// Do nothing if already closed
+	if s.db == nil {
+		return nil
+	}
+
 	s.db.Init()
 	s.db = nil
 	return nil

--- a/utils_test.go
+++ b/utils_test.go
@@ -90,7 +90,7 @@ func newNode(t *testing.T) (*skademlia.Client, string, func()) {
 	client := skademlia.NewClient(addr, keys, skademlia.WithC1(sys.SKademliaC1), skademlia.WithC2(sys.SKademliaC2))
 	client.SetCredentials(noise.NewCredentials(addr, handshake.NewECDH(), cipher.NewAEAD(), client.Protocol()))
 
-	kv, cleanup := store.NewTestKV(t, "level", "db")
+	kv, cleanup := store.NewTestKV(t, "inmem", "db")
 	ledger := NewLedger(kv, client, nil)
 	server := client.Listen()
 	RegisterWaveletServer(server, ledger.Protocol())


### PR DESCRIPTION
The test is suspected to fail intermittently because sometimes when some of the nodes are closed, `grpc.Client` doesn't have time to update its internal state to reflect the closed connection. This affects the outcome of the test as it depends on `client.GetState()`.