### PR TITLE
cmd/wavelet: fix panic when placing stake

### DIFF
--- a/cmd/wavelet/actions.go
+++ b/cmd/wavelet/actions.go
@@ -469,7 +469,7 @@ func (cli *CLI) placeStake(ctx *cli.Context) {
 		return
 	}
 
-	amount, err := strconv.ParseUint(cmd[1], 10, 64)
+	amount, err := strconv.ParseUint(cmd[0], 10, 64)
 	if err != nil {
 		cli.logger.Error().Err(err).
 			Msg("Failed to convert staking amount to a uint64.")


### PR DESCRIPTION
Fix a copy-paste error causing panic due to index out of range error.