### PR TITLE
cmd/wavelet: fix unspecified flag not generating random wallet

### DIFF
--- a/cmd/wavelet/cli.go
+++ b/cmd/wavelet/cli.go
@@ -51,7 +51,7 @@ type CLI struct {
 	completion []string
 }
 
-func NewCLI(client *skademlia.Client, ledger *wavelet.Ledger, keys *skademlia.Keypair) (*CLI, error) {
+func NewCLI(client *skademlia.Client, ledger *wavelet.Ledger, keys *skademlia.Keypair, stdin io.ReadCloser, stdout io.Writer) (*CLI, error) {
 	c := &CLI{
 		client: client,
 		ledger: ledger,
@@ -174,6 +174,8 @@ func NewCLI(client *skademlia.Client, ledger *wavelet.Ledger, keys *skademlia.Ke
 		InterruptPrompt:   "^C",
 		EOFPrompt:         "exit",
 		HistorySearchFold: true,
+		Stdin:             stdin,
+		Stdout:            stdout,
 	})
 
 	if err != nil {

--- a/cmd/wavelet/main.go
+++ b/cmd/wavelet/main.go
@@ -62,6 +62,10 @@ type Config struct {
 }
 
 func main() {
+	Run(os.Args)
+}
+
+func Run(args []string) {
 	log.SetWriter(
 		log.LoggerWavelet,
 		log.NewConsoleWriter(nil, log.FilterFor(
@@ -109,7 +113,6 @@ func main() {
 		}),
 		altsrc.NewStringFlag(cli.StringFlag{
 			Name:   "wallet",
-			Value:  "config/wallet.txt",
 			Usage:  "Path to file containing hex-encoded private key. If the path specified is invalid, or no file exists at the specified path, a random wallet will be generated. Optionally, a 128-length hex-encoded private key to a wallet may also be specified.",
 			EnvVar: "WAVELET_WALLET",
 		}),
@@ -229,7 +232,7 @@ func main() {
 	sort.Sort(cli.FlagsByName(app.Flags))
 	sort.Sort(cli.CommandsByName(app.Commands))
 
-	if err := app.Run(os.Args); err != nil {
+	if err := app.Run(args); err != nil {
 		logger.Fatal().Err(err).
 			Msg("Failed to parse configuration/command-line arguments.")
 	}

--- a/cmd/wavelet/main_test.go
+++ b/cmd/wavelet/main_test.go
@@ -1,17 +1,23 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/perlin-network/noise/skademlia"
+	"github.com/perlin-network/wavelet/sys"
 	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/assert"
 )
@@ -22,7 +28,8 @@ func TestMain(t *testing.T) {
 	port := nextPort(t)
 	apiPort := nextPort(t)
 
-	go Run([]string{"wavelet", "--port", port, "--api.port", apiPort})
+	go Run([]string{"wavelet", "--port", port, "--api.port", apiPort},
+		nopStdin(), ioutil.Discard)
 	waitForAPI(t, apiPort)
 
 	ledger := getLedgerStatusT(t, apiPort)
@@ -37,7 +44,8 @@ func TestMain_WithWalletString(t *testing.T) {
 	port := nextPort(t)
 	apiPort := nextPort(t)
 
-	go Run([]string{"wavelet", "--port", port, "--api.port", apiPort, "--wallet", wallet})
+	go Run([]string{"wavelet", "--port", port, "--api.port", apiPort, "--wallet", wallet},
+		nopStdin(), ioutil.Discard)
 	waitForAPI(t, apiPort)
 
 	ledger := getLedgerStatusT(t, apiPort)
@@ -62,7 +70,8 @@ func TestMain_WithWalletFile(t *testing.T) {
 	port := nextPort(t)
 	apiPort := nextPort(t)
 
-	go Run([]string{"wavelet", "--port", port, "--api.port", apiPort, "--wallet", walletPath})
+	go Run([]string{"wavelet", "--port", port, "--api.port", apiPort, "--wallet", walletPath},
+		nopStdin(), ioutil.Discard)
 	waitForAPI(t, apiPort)
 
 	ledger := getLedgerStatusT(t, apiPort)
@@ -75,13 +84,161 @@ func TestMain_WithInvalidWallet(t *testing.T) {
 	port := nextPort(t)
 	apiPort := nextPort(t)
 
-	go Run([]string{"wavelet", "--port", port, "--api.port", apiPort, "--wallet", wallet})
+	go Run([]string{"wavelet", "--port", port, "--api.port", apiPort, "--wallet", wallet},
+		nopStdin(), ioutil.Discard)
 	waitForAPI(t, apiPort)
 
 	ledger := getLedgerStatusT(t, apiPort)
 	assert.EqualValues(t, "127.0.0.1:"+port, ledger.Address)
 	assert.NotEqual(t, defaultWallet[64:], ledger.PublicKey) // A random wallet should be generated
 	assert.Nil(t, ledger.Peers)
+}
+
+func TestMain_Status(t *testing.T) {
+	port := nextPort(t)
+	apiPort := nextPort(t)
+
+	stdin := make(chan string)
+	stdout := newMockStdout()
+
+	go Run([]string{"wavelet", "--port", port, "--api.port", apiPort, "--wallet", defaultWallet},
+		mockStdin(stdin), stdout)
+
+	waitForAPI(t, apiPort)
+
+	stdin <- "status"
+	stdout.Search(t, "Here is the current status of your node")
+}
+
+func TestMain_Pay(t *testing.T) {
+	keys, err := skademlia.NewKeys(sys.SKademliaC1, sys.SKademliaC2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	port := nextPort(t)
+	apiPort := nextPort(t)
+
+	stdin := make(chan string)
+	stdout := newMockStdout()
+
+	go Run([]string{"wavelet", "--port", port, "--api.port", apiPort, "--wallet", defaultWallet},
+		mockStdin(stdin), stdout)
+
+	waitForAPI(t, apiPort)
+
+	recipient := keys.PublicKey()
+	stdin <- fmt.Sprintf("p %s 99999", hex.EncodeToString(recipient[:]))
+
+	txID := extractTxID(t, stdout.Search(t, "Success! Your payment transaction ID:"))
+
+	var tx *TestTransaction
+	waitFor(t, func() error {
+		tx, err = getTransaction(apiPort, txID)
+		return err
+	})
+
+	assert.EqualValues(t, txID, tx.ID)
+	assert.EqualValues(t, defaultWallet[64:], tx.Sender)
+	assert.EqualValues(t, defaultWallet[64:], tx.Creator)
+}
+
+func TestMain_Find(t *testing.T) {
+	keys, err := skademlia.NewKeys(sys.SKademliaC1, sys.SKademliaC2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	port := nextPort(t)
+	apiPort := nextPort(t)
+
+	stdin := make(chan string)
+	stdout := newMockStdout()
+
+	go Run([]string{"wavelet", "--port", port, "--api.port", apiPort, "--wallet", defaultWallet},
+		mockStdin(stdin), stdout)
+
+	waitForAPI(t, apiPort)
+
+	recipient := keys.PublicKey()
+	stdin <- fmt.Sprintf("p %s 99999", hex.EncodeToString(recipient[:]))
+
+	txID := extractTxID(t, stdout.Search(t, "Success! Your payment transaction ID:"))
+
+	// Wait for the transction to be available
+	waitFor(t, func() error {
+		_, err := getTransaction(apiPort, txID)
+		return err
+	})
+
+	stdin <- fmt.Sprintf("find %s", txID)
+	stdout.Search(t, fmt.Sprintf("Transaction: %s", txID))
+}
+
+func TestMain_PlaceStake(t *testing.T) {
+	port := nextPort(t)
+	apiPort := nextPort(t)
+
+	stdin := make(chan string)
+	stdout := newMockStdout()
+
+	go Run([]string{"wavelet", "--port", port, "--api.port", apiPort, "--wallet", defaultWallet},
+		mockStdin(stdin), stdout)
+
+	waitForAPI(t, apiPort)
+
+	stdin <- "ps 1000"
+
+	txID := extractTxID(t, stdout.Search(t, "Success! Your stake placement transaction ID:"))
+	tx := getTransactionT(t, apiPort, txID)
+
+	assert.EqualValues(t, txID, tx.ID)
+	assert.EqualValues(t, defaultWallet[64:], tx.Sender)
+	assert.EqualValues(t, defaultWallet[64:], tx.Creator)
+}
+
+func TestMain_WithdrawStake(t *testing.T) {
+	port := nextPort(t)
+	apiPort := nextPort(t)
+
+	stdin := make(chan string)
+	stdout := newMockStdout()
+
+	go Run([]string{"wavelet", "--port", port, "--api.port", apiPort, "--wallet", defaultWallet},
+		mockStdin(stdin), stdout)
+
+	waitForAPI(t, apiPort)
+
+	stdin <- "ws 1000"
+
+	txID := extractTxID(t, stdout.Search(t, "Success! Your stake withdrawal transaction ID:"))
+	tx := getTransactionT(t, apiPort, txID)
+
+	assert.EqualValues(t, txID, tx.ID)
+	assert.EqualValues(t, defaultWallet[64:], tx.Sender)
+	assert.EqualValues(t, defaultWallet[64:], tx.Creator)
+}
+
+func TestMain_WithdrawReward(t *testing.T) {
+	port := nextPort(t)
+	apiPort := nextPort(t)
+
+	stdin := make(chan string)
+	stdout := newMockStdout()
+
+	go Run([]string{"wavelet", "--port", port, "--api.port", apiPort, "--wallet", defaultWallet},
+		mockStdin(stdin), stdout)
+
+	waitForAPI(t, apiPort)
+
+	stdin <- "wr 1000"
+
+	txID := extractTxID(t, stdout.Search(t, "Success! Your reward withdrawal transaction ID:"))
+	tx := getTransactionT(t, apiPort, txID)
+
+	assert.EqualValues(t, txID, tx.ID)
+	assert.EqualValues(t, defaultWallet[64:], tx.Sender)
+	assert.EqualValues(t, defaultWallet[64:], tx.Creator)
 }
 
 func nextPort(t *testing.T) string {
@@ -113,6 +270,12 @@ type TestLedgerStatus struct {
 	PublicKey string   `json:"public_key"`
 	Address   string   `json:"address"`
 	Peers     []string `json:"peers"`
+}
+
+type TestTransaction struct {
+	ID      string `json:"id"`
+	Sender  string `json:"sender"`
+	Creator string `json:"creator"`
 }
 
 func getLedgerStatusT(t *testing.T, apiPort string) *TestLedgerStatus {
@@ -151,4 +314,145 @@ func getLedgerStatus(apiPort string) (*TestLedgerStatus, error) {
 	}
 
 	return &ledger, nil
+}
+
+func getTransactionT(t *testing.T, apiPort string, id string) *TestTransaction {
+	tx, err := getTransaction(apiPort, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return tx
+}
+
+func getTransaction(apiPort string, id string) (*TestTransaction, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%s/tx/%s", apiPort, id), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
+	defer cancel()
+
+	req = req.WithContext(ctx)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("expecting GET /tx/%s to return 200, got %d instead", id, resp.StatusCode)
+	}
+
+	var tx TestTransaction
+	if err := json.NewDecoder(resp.Body).Decode(&tx); err != nil {
+		return nil, err
+	}
+
+	return &tx, nil
+}
+
+func nopStdin() io.ReadCloser {
+	return ioutil.NopCloser(strings.NewReader(""))
+}
+
+type mockStdin chan string
+
+func (s mockStdin) Read(dst []byte) (n int, err error) {
+	line := <-s
+	if line == "" {
+		return 0, io.EOF
+	}
+
+	copy(dst, []byte(line+"\n"))
+	return len(line) + 1, nil
+}
+
+func (s mockStdin) Close() error {
+	close(s)
+	return nil
+}
+
+type mockStdout struct {
+	Lines chan string
+	buf   []byte
+	bi    int
+}
+
+func newMockStdout() *mockStdout {
+	return &mockStdout{
+		Lines: make(chan string, 256),
+		buf:   make([]byte, 2048),
+		bi:    0,
+	}
+}
+
+func (s *mockStdout) Write(p []byte) (n int, err error) {
+	ni := bytes.Index(p, []byte{'\n'})
+	if ni < 0 {
+		copy(s.buf[s.bi:], p)
+		s.bi += len(p)
+		return len(p), nil
+	}
+
+	for ni >= 0 {
+		copy(s.buf[s.bi:], p[:ni])
+		s.bi += ni
+
+		s.Lines <- string(s.buf[:s.bi])
+
+		s.bi = 0
+		p = p[ni+1:]
+		ni = bytes.Index(p, []byte{'\n'})
+	}
+
+	return len(p), nil
+}
+
+func (s *mockStdout) Search(t *testing.T, sub string) string {
+	timeout := time.NewTimer(time.Second * 5)
+	for {
+		select {
+		case line := <-s.Lines:
+			if strings.Contains(line, sub) {
+				return line
+			}
+
+		case <-timeout.C:
+			t.Fatal("timed out searching for string in stdout")
+		}
+	}
+}
+
+func extractTxID(t *testing.T, s string) string {
+	if len(s) < 64 {
+		t.Fatal("output does not contain tx id")
+	}
+
+	txID := s[len(s)-64:]
+	if _, err := hex.DecodeString(txID); err != nil {
+		t.Fatal(err)
+	}
+
+	return txID
+}
+
+func waitFor(t *testing.T, fn func() error) {
+	timeout := time.NewTimer(time.Second * 10)
+	ticker := time.NewTicker(time.Second * 1)
+
+	for {
+		select {
+		case <-timeout.C:
+			t.Fatal("timed out waiting")
+
+		case <-ticker.C:
+			if err := fn(); err == nil {
+				return
+			}
+		}
+	}
 }

--- a/cmd/wavelet/main_test.go
+++ b/cmd/wavelet/main_test.go
@@ -16,43 +16,30 @@ import (
 	"testing"
 	"time"
 
-	"github.com/perlin-network/noise/skademlia"
 	"github.com/perlin-network/wavelet"
-	"github.com/perlin-network/wavelet/sys"
 	"github.com/phayes/freeport"
 	"github.com/stretchr/testify/assert"
 )
 
-var defaultWallet = "87a6813c3b4cf534b6ae82db9b1409fa7dbd5c13dba5858970b56084c4a930eb400056ee68a7cc2695222df05ea76875bc27ec6e61e8e62317c336157019c405"
+var wallet1 = "87a6813c3b4cf534b6ae82db9b1409fa7dbd5c13dba5858970b56084c4a930eb400056ee68a7cc2695222df05ea76875bc27ec6e61e8e62317c336157019c405"
 var wallet2 = "85e7450f7cf0d9cd1d1d7bf4169c2f364eea4ba833a7280e0f931a1d92fd92c2696937c2c8df35dba0169de72990b80761e51dd9e2411fa1fce147f68ade830a"
+var wallet3 = "5b9fcd2d6f8e34f4aa472e0c3099fefd25f0ceab9e908196b1dda63e55349d22f03bb6f98c4dfd31f3d448c7ec79fa3eaa92250112ada43471812f4b1ace6467"
 
 func TestMain(t *testing.T) {
-	port := nextPort(t)
-	apiPort := nextPort(t)
+	w := NewTestWavelet(t, nil)
+	defer w.Cleanup()
 
-	cleanup := runWavelet(TestWaveletArgs{Port: port, APIPort: apiPort},
-		nopStdin(), ioutil.Discard)
-	defer cleanup()
-	waitForAPI(t, apiPort)
-
-	ledger := getLedgerStatusT(t, apiPort)
-	assert.EqualValues(t, "127.0.0.1:"+port, ledger.Address)
-	assert.NotEqual(t, defaultWallet[64:], ledger.PublicKey) // A random wallet should be generated
-	assert.Nil(t, ledger.Peers)
+	ledger := w.GetLedgerStatus(t)
+	assert.EqualValues(t, "127.0.0.1:"+w.Port, ledger.Address)
+	assert.NotEqual(t, wallet1[64:], ledger.PublicKey) // A random wallet should be generated
 }
 
 func TestMain_WithWalletString(t *testing.T) {
 	wallet := "b27b880e6e44e3b127186a08bc5698316e8dd99157cec56211560b62141f0851c72096021609681eb8cab244752945b2008e1b51d8bc2208b2b562f35485d5cc"
+	w := NewTestWavelet(t, &TestWaveletConfig{wallet})
+	defer w.Cleanup()
 
-	port := nextPort(t)
-	apiPort := nextPort(t)
-
-	cleanup := runWavelet(TestWaveletArgs{Port: port, APIPort: apiPort, Wallet: wallet},
-		nopStdin(), ioutil.Discard)
-	defer cleanup()
-	waitForAPI(t, apiPort)
-
-	ledger := getLedgerStatusT(t, apiPort)
+	ledger := w.GetLedgerStatus(t)
 	assert.EqualValues(t, wallet[64:], ledger.PublicKey)
 }
 
@@ -71,283 +58,201 @@ func TestMain_WithWalletFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	port := nextPort(t)
-	apiPort := nextPort(t)
+	w := NewTestWavelet(t, &TestWaveletConfig{walletPath})
+	defer w.Cleanup()
 
-	cleanup := runWavelet(TestWaveletArgs{Port: port, APIPort: apiPort, Wallet: walletPath},
-		nopStdin(), ioutil.Discard)
-	defer cleanup()
-	waitForAPI(t, apiPort)
-
-	ledger := getLedgerStatusT(t, apiPort)
+	ledger := w.GetLedgerStatus(t)
 	assert.EqualValues(t, wallet[64:], ledger.PublicKey)
 }
 
 func TestMain_WithInvalidWallet(t *testing.T) {
 	wallet := "foobar"
+	w := NewTestWavelet(t, &TestWaveletConfig{wallet})
+	defer w.Cleanup()
 
-	port := nextPort(t)
-	apiPort := nextPort(t)
-
-	cleanup := runWavelet(TestWaveletArgs{Port: port, APIPort: apiPort, Wallet: wallet},
-		nopStdin(), ioutil.Discard)
-	defer cleanup()
-	waitForAPI(t, apiPort)
-
-	ledger := getLedgerStatusT(t, apiPort)
-	assert.EqualValues(t, "127.0.0.1:"+port, ledger.Address)
-	assert.NotEqual(t, defaultWallet[64:], ledger.PublicKey) // A random wallet should be generated
-	assert.Nil(t, ledger.Peers)
+	ledger := w.GetLedgerStatus(t)
+	assert.NotEqual(t, wallet1[64:], ledger.PublicKey) // A random wallet should be generated
 }
 
 func TestMain_Status(t *testing.T) {
-	port := nextPort(t)
-	apiPort := nextPort(t)
+	w := NewTestWavelet(t, nil)
+	defer w.Cleanup()
 
-	stdin := make(chan string)
-	stdout := newMockStdout()
-
-	cleanup := runWavelet(TestWaveletArgs{Port: port, APIPort: apiPort, Wallet: defaultWallet},
-		mockStdin(stdin), stdout)
-	defer cleanup()
-	waitForAPI(t, apiPort)
-
-	stdin <- "status"
-	stdout.Search(t, "Here is the current status of your node")
+	w.Stdin <- "status"
+	w.Stdout.Search(t, "Here is the current status of your node")
 }
 
 func TestMain_Pay(t *testing.T) {
-	keys, err := skademlia.NewKeys(sys.SKademliaC1, sys.SKademliaC2)
-	if err != nil {
-		t.Fatal(err)
-	}
+	alice := NewTestWavelet(t, &TestWaveletConfig{wallet2})
+	defer alice.Cleanup()
 
-	port := nextPort(t)
-	apiPort := nextPort(t)
+	bob := alice.Testnet.AddNode(t, 0)
 
-	stdin := make(chan string)
-	stdout := newMockStdout()
+	time.Sleep(time.Second * 1)
 
-	cleanup := runWavelet(TestWaveletArgs{Port: port, APIPort: apiPort, Wallet: defaultWallet},
-		mockStdin(stdin), stdout)
-	defer cleanup()
-	waitForAPI(t, apiPort)
+	recipient := bob.PublicKey()
+	alice.Stdin <- fmt.Sprintf("p %s 99999", hex.EncodeToString(recipient[:]))
 
-	recipient := keys.PublicKey()
-	stdin <- fmt.Sprintf("p %s 99999", hex.EncodeToString(recipient[:]))
-
-	txID := extractTxID(t, stdout.Search(t, "Success! Your payment transaction ID:"))
-
-	var tx *TestTransaction
-	waitFor(t, func() error {
-		tx, err = getTransaction(apiPort, txID)
-		return err
-	})
+	txID := extractTxID(t, alice.Stdout.Search(t, "Success! Your payment transaction ID:"))
+	tx := alice.WaitForTransction(t, txID)
 
 	assert.EqualValues(t, txID, tx.ID)
-	assert.EqualValues(t, defaultWallet[64:], tx.Sender)
-	assert.EqualValues(t, defaultWallet[64:], tx.Creator)
+	assert.EqualValues(t, alice.PublicKey, tx.Sender)
+	assert.EqualValues(t, alice.PublicKey, tx.Creator)
+
+	<-bob.WaitForConsensus()
+	assert.EqualValues(t, 99999, bob.Balance())
 }
 
 func TestMain_Spawn(t *testing.T) {
-	port := nextPort(t)
-	apiPort := nextPort(t)
+	w := NewTestWavelet(t, &TestWaveletConfig{wallet2})
+	defer w.Cleanup()
 
-	stdin := make(chan string)
-	stdout := newMockStdout()
+	for i := 0; i < 3; i++ {
+		w.Testnet.AddNode(t, 0)
+	}
 
-	cleanup := runWavelet(TestWaveletArgs{Port: port, APIPort: apiPort, Wallet: defaultWallet},
-		mockStdin(stdin), stdout)
-	defer cleanup()
-	waitForAPI(t, apiPort)
+	time.Sleep(time.Second * 1)
 
-	stdin <- "spawn ../../testdata/transfer_back.wasm"
+	w.Stdin <- "spawn ../../testdata/transfer_back.wasm"
 
-	txID := extractTxID(t, stdout.Search(t, "Success! Your smart contracts ID:"))
-
-	var tx *TestTransaction
-	var err error
-	waitFor(t, func() error {
-		tx, err = getTransaction(apiPort, txID)
-		return err
-	})
+	txID := extractTxID(t, w.Stdout.Search(t, "Success! Your smart contracts ID:"))
+	tx := w.WaitForTransction(t, txID)
 
 	assert.EqualValues(t, txID, tx.ID)
-	assert.EqualValues(t, defaultWallet[64:], tx.Sender)
-	assert.EqualValues(t, defaultWallet[64:], tx.Creator)
+	assert.EqualValues(t, w.PublicKey, tx.Sender)
+	assert.EqualValues(t, w.PublicKey, tx.Creator)
 }
 
 func TestMain_Call(t *testing.T) {
-	testnet := wavelet.NewTestNetwork(t)
-	defer testnet.Cleanup()
+	w := NewTestWavelet(t, &TestWaveletConfig{wallet2})
+	defer w.Cleanup()
 
-	node := testnet.AddNode(t, 0)
-
-	port := nextPort(t)
-	apiPort := nextPort(t)
-
-	stdin := make(chan string)
-	stdout := newMockStdout()
-
-	cleanup := runWavelet(TestWaveletArgs{Port: port, APIPort: apiPort, Wallet: wallet2, Peers: []string{node.Addr()}},
-		mockStdin(stdin), stdout)
-	defer cleanup()
-	waitForAPI(t, apiPort)
+	for i := 0; i < 3; i++ {
+		w.Testnet.AddNode(t, 0)
+	}
 
 	time.Sleep(time.Second * 1)
 
-	stdin <- "spawn ../../testdata/transfer_back.wasm"
+	w.Stdin <- "spawn ../../testdata/transfer_back.wasm"
 
-	txID := extractTxID(t, stdout.Search(t, "Success! Your smart contracts ID:"))
+	txID := extractTxID(t, w.Stdout.Search(t, "Success! Your smart contracts ID:"))
 
-	// Wait for consensus
-	stdout.Search(t, "Finalized consensus round")
+	w.WaitForConsensus(t)
 
-	var tx *TestTransaction
-	var err error
-	waitFor(t, func() error {
-		tx, err = getTransaction(apiPort, txID)
-		return err
-	})
-
-	stdin <- fmt.Sprintf("call %s 1000 100000 on_money_received", tx.ID)
-	stdout.Search(t, "Your smart contract invocation transaction ID:")
+	tx := w.WaitForTransction(t, txID)
+	w.Stdin <- fmt.Sprintf("call %s 1000 100000 on_money_received", tx.ID)
+	w.Stdout.Search(t, "Your smart contract invocation transaction ID:")
 }
 
 func TestMain_DepositGas(t *testing.T) {
-	testnet := wavelet.NewTestNetwork(t)
-	defer testnet.Cleanup()
+	w := NewTestWavelet(t, &TestWaveletConfig{wallet2})
+	defer w.Cleanup()
 
-	node := testnet.AddNode(t, 0)
-
-	port := nextPort(t)
-	apiPort := nextPort(t)
-
-	stdin := make(chan string)
-	stdout := newMockStdout()
-
-	cleanup := runWavelet(TestWaveletArgs{Port: port, APIPort: apiPort, Wallet: wallet2, Peers: []string{node.Addr()}},
-		mockStdin(stdin), stdout)
-	defer cleanup()
-	waitForAPI(t, apiPort)
+	for i := 0; i < 3; i++ {
+		w.Testnet.AddNode(t, 0)
+	}
 
 	time.Sleep(time.Second * 1)
 
-	stdin <- "spawn ../../testdata/transfer_back.wasm"
+	w.Stdin <- "spawn ../../testdata/transfer_back.wasm"
 
-	txID := extractTxID(t, stdout.Search(t, "Success! Your smart contracts ID:"))
+	txID := extractTxID(t, w.Stdout.Search(t, "Success! Your smart contracts ID:"))
 
-	// Wait for consensus
-	stdout.Search(t, "Finalized consensus round")
+	w.WaitForConsensus(t)
 
-	var tx *TestTransaction
-	var err error
-	waitFor(t, func() error {
-		tx, err = getTransaction(apiPort, txID)
-		return err
-	})
-
-	stdin <- fmt.Sprintf("deposit-gas %s 99999", tx.ID)
-	stdout.Search(t, "Your gas deposit transaction ID:")
+	tx := w.WaitForTransction(t, txID)
+	w.Stdin <- fmt.Sprintf("deposit-gas %s 99999", tx.ID)
+	w.Stdout.Search(t, "Your gas deposit transaction ID:")
 }
 
 func TestMain_Find(t *testing.T) {
-	keys, err := skademlia.NewKeys(sys.SKademliaC1, sys.SKademliaC2)
-	if err != nil {
-		t.Fatal(err)
-	}
+	alice := NewTestWavelet(t, &TestWaveletConfig{wallet2})
+	defer alice.Cleanup()
 
-	port := nextPort(t)
-	apiPort := nextPort(t)
+	bob := alice.Testnet.AddNode(t, 0)
 
-	stdin := make(chan string)
-	stdout := newMockStdout()
+	time.Sleep(time.Second * 1)
 
-	cleanup := runWavelet(TestWaveletArgs{Port: port, APIPort: apiPort, Wallet: defaultWallet},
-		mockStdin(stdin), stdout)
-	defer cleanup()
-	waitForAPI(t, apiPort)
+	recipient := bob.PublicKey()
+	alice.Stdin <- fmt.Sprintf("p %s 99999", hex.EncodeToString(recipient[:]))
 
-	recipient := keys.PublicKey()
-	stdin <- fmt.Sprintf("p %s 99999", hex.EncodeToString(recipient[:]))
+	txID := extractTxID(t, alice.Stdout.Search(t, "Success! Your payment transaction ID:"))
+	alice.WaitForTransction(t, txID)
 
-	out := stdout.Search(t, "Success! Your payment transaction ID:")
-	txID := extractTxID(t, out)
-
-	// Wait for the transction to be available
-	waitFor(t, func() error {
-		_, err := getTransaction(apiPort, txID)
-		return err
-	})
-
-	stdin <- fmt.Sprintf("find %s", txID)
-	stdout.Search(t, fmt.Sprintf("Transaction: %s", txID))
+	alice.Stdin <- fmt.Sprintf("find %s", txID)
+	alice.Stdout.Search(t, fmt.Sprintf("Transaction: %s", txID))
 }
 
 func TestMain_PlaceStake(t *testing.T) {
-	port := nextPort(t)
-	apiPort := nextPort(t)
+	alice := NewTestWavelet(t, &TestWaveletConfig{wallet2})
+	defer alice.Cleanup()
 
-	stdin := make(chan string)
-	stdout := newMockStdout()
+	bob := alice.Testnet.AddNode(t, 0)
 
-	cleanup := runWavelet(TestWaveletArgs{Port: port, APIPort: apiPort, Wallet: defaultWallet},
-		mockStdin(stdin), stdout)
-	defer cleanup()
-	waitForAPI(t, apiPort)
+	time.Sleep(time.Second * 1)
 
-	stdin <- "ps 1000"
+	alice.Stdin <- "ps 1000"
 
-	txID := extractTxID(t, stdout.Search(t, "Success! Your stake placement transaction ID:"))
-	tx := getTransactionT(t, apiPort, txID)
+	txID := extractTxID(t, alice.Stdout.Search(t, "Success! Your stake placement transaction ID:"))
+	tx := alice.WaitForTransction(t, txID)
 
 	assert.EqualValues(t, txID, tx.ID)
-	assert.EqualValues(t, defaultWallet[64:], tx.Sender)
-	assert.EqualValues(t, defaultWallet[64:], tx.Creator)
+	assert.EqualValues(t, alice.PublicKey, tx.Sender)
+	assert.EqualValues(t, alice.PublicKey, tx.Creator)
+
+	<-bob.WaitForConsensus()
+	assert.EqualValues(t, 1000, bob.StakeWithPublicKey(asAccountID(t, alice.PublicKey)))
 }
 
 func TestMain_WithdrawStake(t *testing.T) {
-	port := nextPort(t)
-	apiPort := nextPort(t)
+	alice := NewTestWavelet(t, &TestWaveletConfig{wallet2})
+	defer alice.Cleanup()
 
-	stdin := make(chan string)
-	stdout := newMockStdout()
+	bob := alice.Testnet.AddNode(t, 0)
 
-	cleanup := runWavelet(TestWaveletArgs{Port: port, APIPort: apiPort, Wallet: defaultWallet},
-		mockStdin(stdin), stdout)
-	defer cleanup()
-	waitForAPI(t, apiPort)
+	time.Sleep(time.Second * 1)
 
-	stdin <- "ws 1000"
+	alice.Stdin <- "ps 1000"
 
-	txID := extractTxID(t, stdout.Search(t, "Success! Your stake withdrawal transaction ID:"))
-	tx := getTransactionT(t, apiPort, txID)
+	txID := extractTxID(t, alice.Stdout.Search(t, "Success! Your stake placement transaction ID:"))
+	alice.WaitForTransction(t, txID)
+
+	alice.WaitForConsensus(t)
+
+	alice.Stdin <- "ws 500"
+
+	txID = extractTxID(t, alice.Stdout.Search(t, "Success! Your stake withdrawal transaction ID:"))
+	tx := alice.WaitForTransction(t, txID)
 
 	assert.EqualValues(t, txID, tx.ID)
-	assert.EqualValues(t, defaultWallet[64:], tx.Sender)
-	assert.EqualValues(t, defaultWallet[64:], tx.Creator)
+	assert.EqualValues(t, alice.PublicKey, tx.Sender)
+	assert.EqualValues(t, alice.PublicKey, tx.Creator)
+
+	<-bob.WaitForConsensus()
+	assert.EqualValues(t, 500, bob.StakeWithPublicKey(asAccountID(t, alice.PublicKey)))
 }
 
 func TestMain_WithdrawReward(t *testing.T) {
-	port := nextPort(t)
-	apiPort := nextPort(t)
+	w := NewTestWavelet(t, &TestWaveletConfig{wallet2})
+	defer w.Cleanup()
 
-	stdin := make(chan string)
-	stdout := newMockStdout()
+	for i := 0; i < 3; i++ {
+		w.Testnet.AddNode(t, 0)
+	}
 
-	cleanup := runWavelet(TestWaveletArgs{Port: port, APIPort: apiPort, Wallet: defaultWallet},
-		mockStdin(stdin), stdout)
-	defer cleanup()
-	waitForAPI(t, apiPort)
+	time.Sleep(time.Second * 1)
 
-	stdin <- "wr 1000"
+	w.Stdin <- "wr 1000"
 
-	txID := extractTxID(t, stdout.Search(t, "Success! Your reward withdrawal transaction ID:"))
-	tx := getTransactionT(t, apiPort, txID)
+	txID := extractTxID(t, w.Stdout.Search(t, "Success! Your reward withdrawal transaction ID:"))
+	tx := w.WaitForTransction(t, txID)
 
 	assert.EqualValues(t, txID, tx.ID)
-	assert.EqualValues(t, defaultWallet[64:], tx.Sender)
-	assert.EqualValues(t, defaultWallet[64:], tx.Creator)
+	assert.EqualValues(t, w.PublicKey, tx.Sender)
+	assert.EqualValues(t, w.PublicKey, tx.Creator)
+
+	// TODO: check if reward is actually withdrawn
 }
 
 func nextPort(t *testing.T) string {
@@ -390,83 +295,6 @@ type TestTransaction struct {
 	ID      string `json:"id"`
 	Sender  string `json:"sender"`
 	Creator string `json:"creator"`
-}
-
-func getLedgerStatusT(t *testing.T, apiPort string) *TestLedgerStatus {
-	ledger, err := getLedgerStatus(apiPort)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return ledger
-}
-
-func getLedgerStatus(apiPort string) (*TestLedgerStatus, error) {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%s/ledger", apiPort), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
-	defer cancel()
-
-	req = req.WithContext(ctx)
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("expecting GET /ledger to return 200, got %d instead", resp.StatusCode)
-	}
-
-	var ledger TestLedgerStatus
-	if err := json.NewDecoder(resp.Body).Decode(&ledger); err != nil {
-		return nil, err
-	}
-
-	return &ledger, nil
-}
-
-func getTransactionT(t *testing.T, apiPort string, id string) *TestTransaction {
-	tx, err := getTransaction(apiPort, id)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return tx
-}
-
-func getTransaction(apiPort string, id string) (*TestTransaction, error) {
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%s/tx/%s", apiPort, id), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
-	defer cancel()
-
-	req = req.WithContext(ctx)
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("expecting GET /tx/%s to return 200, got %d instead", id, resp.StatusCode)
-	}
-
-	var tx TestTransaction
-	if err := json.NewDecoder(resp.Body).Decode(&tx); err != nil {
-		return nil, err
-	}
-
-	return &tx, nil
 }
 
 func nopStdin() io.ReadCloser {
@@ -526,6 +354,8 @@ func (s *mockStdout) Write(p []byte) (n int, err error) {
 }
 
 func (s *mockStdout) Search(t *testing.T, sub string) string {
+	t.Helper()
+
 	timeout := time.NewTimer(time.Second * 5)
 	for {
 		select {
@@ -570,27 +400,161 @@ func waitFor(t *testing.T, fn func() error) {
 	}
 }
 
-type TestWaveletArgs struct {
-	Port    string
-	APIPort string
-	Wallet  string
-	Peers   []string
+type TestWavelet struct {
+	Testnet   *wavelet.TestNetwork
+	Port      string
+	APIPort   string
+	PublicKey string
+	Stdin     mockStdin
+	Stdout    *mockStdout
 }
 
-func runWavelet(args TestWaveletArgs, stdin io.ReadCloser, stdout io.Writer) func() {
-	rawArgs := []string{"wavelet", "--port", args.Port, "--api.port", args.APIPort}
-	if args.Wallet != "" {
-		rawArgs = append(rawArgs, []string{"--wallet", args.Wallet}...)
-	}
-	if args.Peers != nil {
-		rawArgs = append(rawArgs, args.Peers...)
+func (w *TestWavelet) Cleanup() {
+	close(w.Stdin)
+	w.Testnet.Cleanup()
+
+	// Since Ledger doesn't have a proper cleanup method yet, just sleep
+	time.Sleep(time.Millisecond * 500)
+}
+
+type TestWaveletConfig struct {
+	Wallet string
+}
+
+func NewTestWavelet(t *testing.T, cfg *TestWaveletConfig) *TestWavelet {
+	testnet := wavelet.NewTestNetwork(t)
+
+	port := nextPort(t)
+	apiPort := nextPort(t)
+
+	args := []string{"wavelet", "--port", port, "--api.port", apiPort}
+	if cfg != nil && cfg.Wallet != "" {
+		args = append(args, []string{"--wallet", cfg.Wallet}...)
 	}
 
-	go Run(rawArgs, stdin, stdout, true)
-	return func() {
-		stdin.Close()
+	// Bootstrap with the faucet
+	args = append(args, testnet.Faucet().Addr())
 
-		// Since Ledger doesn't have a proper cleanup method yet, just sleep
-		time.Sleep(time.Millisecond * 500)
+	stdin := mockStdin(make(chan string))
+	stdout := newMockStdout()
+
+	go Run(args, stdin, stdout, true)
+	waitForAPI(t, apiPort)
+
+	w := &TestWavelet{
+		Testnet: testnet,
+		Port:    port,
+		APIPort: apiPort,
+		Stdin:   stdin,
+		Stdout:  stdout,
 	}
+	w.PublicKey = w.GetLedgerStatus(t).PublicKey
+
+	return w
+}
+
+func (w *TestWavelet) GetLedgerStatus(t *testing.T) *TestLedgerStatus {
+	ledger, err := getLedgerStatus(w.APIPort)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ledger
+}
+
+func getLedgerStatus(apiPort string) (*TestLedgerStatus, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%s/ledger", apiPort), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
+	defer cancel()
+
+	req = req.WithContext(ctx)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("expecting GET /ledger to return 200, got %d instead", resp.StatusCode)
+	}
+
+	var ledger TestLedgerStatus
+	if err := json.NewDecoder(resp.Body).Decode(&ledger); err != nil {
+		return nil, err
+	}
+
+	return &ledger, nil
+}
+
+func (w *TestWavelet) WaitForTransction(t *testing.T, id string) *TestTransaction {
+	var tx *TestTransaction
+	var err error
+	waitFor(t, func() error {
+		tx, err = getTransaction(w.APIPort, id)
+		return err
+	})
+
+	return tx
+}
+
+func (w *TestWavelet) GetTransaction(t *testing.T, id string) *TestTransaction {
+	tx, err := getTransaction(w.APIPort, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return tx
+}
+
+func getTransaction(apiPort string, id string) (*TestTransaction, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%s/tx/%s", apiPort, id), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
+	defer cancel()
+
+	req = req.WithContext(ctx)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("expecting GET /tx/%s to return 200, got %d instead", id, resp.StatusCode)
+	}
+
+	var tx TestTransaction
+	if err := json.NewDecoder(resp.Body).Decode(&tx); err != nil {
+		return nil, err
+	}
+
+	return &tx, nil
+}
+
+func (w *TestWavelet) WaitForConsensus(t *testing.T) {
+	t.Helper()
+	w.Stdout.Search(t, "Finalized consensus round")
+}
+
+func asAccountID(t *testing.T, s string) wavelet.AccountID {
+	t.Helper()
+
+	var accountID wavelet.AccountID
+	key, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	copy(accountID[:], key)
+	return accountID
 }

--- a/cmd/wavelet/main_test.go
+++ b/cmd/wavelet/main_test.go
@@ -441,7 +441,7 @@ func extractTxID(t *testing.T, s string) string {
 }
 
 func waitFor(t *testing.T, fn func() error) {
-	timeout := time.NewTimer(time.Second * 10)
+	timeout := time.NewTimer(time.Second * 30)
 	ticker := time.NewTicker(time.Second * 1)
 
 	for {

--- a/cmd/wavelet/main_test.go
+++ b/cmd/wavelet/main_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/phayes/freeport"
+	"github.com/stretchr/testify/assert"
+)
+
+var defaultWallet = "87a6813c3b4cf534b6ae82db9b1409fa7dbd5c13dba5858970b56084c4a930eb400056ee68a7cc2695222df05ea76875bc27ec6e61e8e62317c336157019c405"
+
+func TestMain(t *testing.T) {
+	port := nextPort(t)
+	apiPort := nextPort(t)
+
+	go Run([]string{"wavelet", "--port", port, "--api.port", apiPort})
+	waitForAPI(t, apiPort)
+
+	ledger := getLedgerStatusT(t, apiPort)
+	assert.EqualValues(t, "127.0.0.1:"+port, ledger.Address)
+	assert.NotEqual(t, defaultWallet[64:], ledger.PublicKey) // A random wallet should be generated
+	assert.Nil(t, ledger.Peers)
+}
+
+func TestMain_WithWalletString(t *testing.T) {
+	wallet := "b27b880e6e44e3b127186a08bc5698316e8dd99157cec56211560b62141f0851c72096021609681eb8cab244752945b2008e1b51d8bc2208b2b562f35485d5cc"
+
+	port := nextPort(t)
+	apiPort := nextPort(t)
+
+	go Run([]string{"wavelet", "--port", port, "--api.port", apiPort, "--wallet", wallet})
+	waitForAPI(t, apiPort)
+
+	ledger := getLedgerStatusT(t, apiPort)
+	assert.EqualValues(t, wallet[64:], ledger.PublicKey)
+}
+
+func TestMain_WithWalletFile(t *testing.T) {
+	wallet := "d6acf5caca96e9da2088bc3a051ed938749145c3f3f7b5bd81aefeb46c12f9e901e4d5b4f51ef76a9a9cc511af910964943404172347b6a01bcfe65d768c9354"
+
+	// Write wallet to a temporary file
+	dir, err := ioutil.TempDir("", "wavelet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	walletPath := filepath.Join(dir, "wallet.txt")
+	if err := ioutil.WriteFile(walletPath, []byte(wallet), 0666); err != nil {
+		t.Fatal(err)
+	}
+
+	port := nextPort(t)
+	apiPort := nextPort(t)
+
+	go Run([]string{"wavelet", "--port", port, "--api.port", apiPort, "--wallet", walletPath})
+	waitForAPI(t, apiPort)
+
+	ledger := getLedgerStatusT(t, apiPort)
+	assert.EqualValues(t, wallet[64:], ledger.PublicKey)
+}
+
+func TestMain_WithInvalidWallet(t *testing.T) {
+	wallet := "foobar"
+
+	port := nextPort(t)
+	apiPort := nextPort(t)
+
+	go Run([]string{"wavelet", "--port", port, "--api.port", apiPort, "--wallet", wallet})
+	waitForAPI(t, apiPort)
+
+	ledger := getLedgerStatusT(t, apiPort)
+	assert.EqualValues(t, "127.0.0.1:"+port, ledger.Address)
+	assert.NotEqual(t, defaultWallet[64:], ledger.PublicKey) // A random wallet should be generated
+	assert.Nil(t, ledger.Peers)
+}
+
+func nextPort(t *testing.T) string {
+	port, err := freeport.GetFreePort()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strconv.Itoa(port)
+}
+
+func waitForAPI(t *testing.T, apiPort string) {
+	timeout := time.NewTimer(time.Second * 5)
+	tick := time.NewTicker(time.Second * 1)
+
+	for {
+		select {
+		case <-timeout.C:
+			t.Fatal("timed out waiting for API")
+
+		case <-tick.C:
+			if _, err := getLedgerStatus(apiPort); err == nil {
+				return
+			}
+		}
+	}
+}
+
+type TestLedgerStatus struct {
+	PublicKey string   `json:"public_key"`
+	Address   string   `json:"address"`
+	Peers     []string `json:"peers"`
+}
+
+func getLedgerStatusT(t *testing.T, apiPort string) *TestLedgerStatus {
+	ledger, err := getLedgerStatus(apiPort)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ledger
+}
+
+func getLedgerStatus(apiPort string) (*TestLedgerStatus, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%s/ledger", apiPort), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
+	defer cancel()
+
+	req = req.WithContext(ctx)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("expecting GET /ledger to return 200, got %d instead", resp.StatusCode)
+	}
+
+	var ledger TestLedgerStatus
+	if err := json.NewDecoder(resp.Body).Decode(&ledger); err != nil {
+		return nil, err
+	}
+
+	return &ledger, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/huandu/skiplist v0.0.0-20180112095830-8e883b265e1b
 	github.com/perlin-network/life v0.0.0-20190723115110-3091ed0c1be8
 	github.com/perlin-network/noise v0.0.0-20190527211417-79abfb78fdba
+	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d
 	github.com/pkg/errors v0.8.1
 	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/perlin-network/noise v0.0.0-20190527211417-79abfb78fdba h1:SZX6pHLS2v
 github.com/perlin-network/noise v0.0.0-20190527211417-79abfb78fdba/go.mod h1:1Ca3rEoDZseet9F06+H47KpsOr+ZgpbbJO7Dg9WC4lM=
 github.com/perlin-network/wagon v0.3.1-0.20180825141017-f8cb99b55a39 h1:CYHXy6CWxxL7ugjvCbTELOm2j5iRLEWGPl3AQYvretw=
 github.com/perlin-network/wagon v0.3.1-0.20180825141017-f8cb99b55a39/go.mod h1:zHOMvbitcZek8oshsMO5VpyBjWjV9X8cn8WTZwdebpM=
+github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 h1:JhzVVoYvbOACxoUmOs6V/G4D5nPVUW73rKvXxP4XUJc=
+github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d h1:U+PMnTlV2tu7RuMK5etusZG3Cf+rpow5hqQByeCzJ2g=
 github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d/go.mod h1:lXfE4PvvTW5xOjO6Mba8zDPyw8M93B6AQ7frTGnMlA8=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=

--- a/testutil.go
+++ b/testutil.go
@@ -39,6 +39,10 @@ func (n *TestNetwork) Cleanup() {
 	n.faucet.Cleanup()
 }
 
+func (n *TestNetwork) Faucet() *TestLedger {
+	return n.faucet
+}
+
 func (n *TestNetwork) AddNode(t testing.TB, startingBalance uint64) *TestLedger {
 	node := NewTestLedger(t, TestLedgerConfig{
 		Peers: []string{n.faucet.Addr()},
@@ -158,6 +162,12 @@ func (l *TestLedger) Stake() uint64 {
 	snapshot := l.ledger.Snapshot()
 	stake, _ := ReadAccountStake(snapshot, l.PublicKey())
 	return stake
+}
+
+func (l *TestLedger) StakeWithPublicKey(key AccountID) uint64 {
+	snapshot := l.ledger.Snapshot()
+	balance, _ := ReadAccountStake(snapshot, key)
+	return balance
 }
 
 func (l *TestLedger) StakeOfAccount(node *TestLedger) uint64 {


### PR DESCRIPTION
If `--wallet` is not specified when running `wavelet`, it is supposed to generate a random wallet. Currently, it will use `wallet/config.txt` by default.

Other than that, this PR adds tests for `cmd/wavelet`.

TODO:

- [x] Add at least 1 test case for each action
- [x] Setup a testnet for each test and verify that the action actually run (currently each test only verifies that the action is successful by checking stdout)
- [x] Test calling smart contract with parameters (check payload is correct)

    ![Screenshot from 2019-08-14 00-36-59](https://user-images.githubusercontent.com/1431045/62959583-b7523500-be2b-11e9-990b-2b0a7148b33d.png)
