### PR TITLE
Queue transaction

### DIFF
--- a/api/mod.go
+++ b/api/mod.go
@@ -218,13 +218,13 @@ func (g *Gateway) sendTransaction(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	tx := wavelet.AttachSenderToTransaction(
-		g.keys,
-		wavelet.Transaction{Tag: sys.Tag(req.Tag), Payload: req.payload, Creator: req.creator, CreatorSignature: req.signature},
-		g.ledger.Graph().FindEligibleParents()...,
-	)
-
-	err = g.ledger.AddTransaction(tx)
+	tx := wavelet.Transaction{
+		Tag:              sys.Tag(req.Tag),
+		Payload:          req.payload,
+		Creator:          req.creator,
+		CreatorSignature: req.signature,
+	}
+	err = g.ledger.QueueTransaction(tx)
 
 	if err != nil && errors.Cause(err) != wavelet.ErrMissingParents {
 		g.renderError(ctx, ErrInternal(errors.Wrap(err, "error adding your transaction to graph")))

--- a/api/mod.go
+++ b/api/mod.go
@@ -224,7 +224,7 @@ func (g *Gateway) sendTransaction(ctx *fasthttp.RequestCtx) {
 		Creator:          req.creator,
 		CreatorSignature: req.signature,
 	}
-	err = g.ledger.QueueTransaction(tx)
+	tx, err = g.ledger.QueueTransaction(tx)
 
 	if err != nil && errors.Cause(err) != wavelet.ErrMissingParents {
 		g.renderError(ctx, ErrInternal(errors.Wrap(err, "error adding your transaction to graph")))

--- a/cmd/graph/main.go
+++ b/cmd/graph/main.go
@@ -162,8 +162,8 @@ func main() {
 		}
 
 		for i := uint64(0); i < count; i++ {
-			tx := wavelet.AttachSenderToTransaction(keys, wavelet.NewTransaction(keys, sys.TagBatch, batch.Marshal()))
-			if err := ledger.AddTransaction(tx); err != nil && errors.Cause(err) != wavelet.ErrMissingParents {
+			tx := wavelet.NewTransaction(keys, sys.TagBatch, batch.Marshal())
+			if tx, err := ledger.QueueTransaction(tx); err != nil && errors.Cause(err) != wavelet.ErrMissingParents {
 				fmt.Printf("error adding tx to graph [%v]: %+v\n", err, tx)
 			}
 		}

--- a/cmd/wavelet/actions.go
+++ b/cmd/wavelet/actions.go
@@ -572,7 +572,8 @@ func (cli *CLI) withdrawReward(ctx *cli.Context) {
 }
 
 func (cli *CLI) sendTransaction(tx wavelet.Transaction) (wavelet.Transaction, error) {
-	if err := cli.ledger.QueueTransaction(tx); err != nil && errors.Cause(err) != wavelet.ErrMissingParents {
+	tx, err := cli.ledger.QueueTransaction(tx)
+	if err != nil && errors.Cause(err) != wavelet.ErrMissingParents {
 		cli.logger.
 			Err(err).
 			Hex("tx_id", tx.ID[:]).

--- a/genesis.go
+++ b/genesis.go
@@ -21,6 +21,7 @@ package wavelet
 
 import (
 	"encoding/hex"
+
 	"github.com/perlin-network/wavelet/avl"
 	"github.com/perlin-network/wavelet/log"
 	"github.com/pkg/errors"
@@ -155,5 +156,5 @@ func performInception(tree *avl.Tree, genesis *string) Round {
 	tx := Transaction{}
 	tx.rehash()
 
-	return NewRound(0, tree.Checksum(), 0, Transaction{}, tx)
+	return NewRound(0, tree.Checksum(), 0, 0, 0, Transaction{}, tx)
 }

--- a/genesis.go
+++ b/genesis.go
@@ -156,5 +156,5 @@ func performInception(tree *avl.Tree, genesis *string) Round {
 	tx := Transaction{}
 	tx.rehash()
 
-	return NewRound(0, tree.Checksum(), 0, 0, 0, Transaction{}, tx)
+	return NewRound(0, tree.Checksum(), 0, Transaction{}, tx)
 }

--- a/ledger.go
+++ b/ledger.go
@@ -772,9 +772,6 @@ FINALIZE_ROUNDS:
 			continue
 		}
 
-		finalized.Rejected = uint64(results.rejectedCount)
-		finalized.Ignored = uint64(results.ignoredCount)
-
 		pruned, err := l.rounds.Save(finalized)
 		if err != nil {
 			fmt.Printf("Failed to save finalized round to our database: %v\n", err)

--- a/ledger.go
+++ b/ledger.go
@@ -591,13 +591,7 @@ FINALIZE_ROUNDS:
 				continue
 			}
 
-			candidate := NewRound(
-				current.Index+1,
-				results.snapshot.Checksum(),
-				uint64(results.appliedCount),
-				uint64(results.rejectedCount),
-				uint64(results.ignoredCount),
-				current.End, *eligible)
+			candidate := NewRound(current.Index+1, results.snapshot.Checksum(), uint64(results.appliedCount), current.End, *eligible)
 			l.finalizer.Prefer(&candidate)
 
 			continue FINALIZE_ROUNDS
@@ -777,6 +771,9 @@ FINALIZE_ROUNDS:
 			fmt.Printf("Expected finalized rounds merkle root to be %x, but got %x.\n", finalized.Merkle, results.snapshot.Checksum())
 			continue
 		}
+
+		finalized.Rejected = uint64(results.rejectedCount)
+		finalized.Ignored = uint64(results.ignoredCount)
 
 		pruned, err := l.rounds.Save(finalized)
 		if err != nil {

--- a/ledger.go
+++ b/ledger.go
@@ -591,7 +591,13 @@ FINALIZE_ROUNDS:
 				continue
 			}
 
-			candidate := NewRound(current.Index+1, results.snapshot.Checksum(), uint64(results.appliedCount), current.End, *eligible)
+			candidate := NewRound(
+				current.Index+1,
+				results.snapshot.Checksum(),
+				uint64(results.appliedCount),
+				uint64(results.rejectedCount),
+				uint64(results.ignoredCount),
+				current.End, *eligible)
 			l.finalizer.Prefer(&candidate)
 
 			continue FINALIZE_ROUNDS

--- a/ledger.go
+++ b/ledger.go
@@ -524,8 +524,8 @@ func (l *Ledger) FinalizeRounds() {
 FINALIZE_ROUNDS:
 	for {
 		// Add sender transactions waiting in the queue
-		txAvailable := true
-		for txAvailable {
+	TX_QUEUE:
+		for {
 			select {
 			case entry := <-l.txQueue:
 				tx := AttachSenderToTransaction(
@@ -535,7 +535,7 @@ FINALIZE_ROUNDS:
 				entry.Done <- l.addTransaction(tx)
 
 			default:
-				txAvailable = false
+				break TX_QUEUE
 			}
 		}
 

--- a/ledger.go
+++ b/ledger.go
@@ -176,8 +176,13 @@ func NewLedger(kv store.KV, client *skademlia.Client, opts ...Option) *Ledger {
 
 // QueueTransaction queues the transaction to be added to the ledger.
 // It should only be called by the sender.
-func (l *Ledger) QueueTransaction(tx Transaction) {
+func (l *Ledger) QueueTransaction(tx Transaction) error {
+	if tx.Sender != l.client.Keys().PublicKey() {
+		return fmt.Errorf("cannot queue transaction not from sender")
+	}
+
 	l.txQueue <- tx
+	return nil
 }
 
 // addTransaction adds a transaction to the ledger. If the transaction has

--- a/ledger_test.go
+++ b/ledger_test.go
@@ -197,6 +197,10 @@ func TestLedger_PayInsufficientBalance(t *testing.T) {
 	for _, node := range testnet.Nodes() {
 		assert.EqualValues(t, aliceBalance, node.BalanceOfAccount(alice))
 		assert.EqualValues(t, 100, node.BalanceOfAccount(bob))
+
+		// All nodes should have rejected the tx
+		round := node.ledger.Rounds().Latest()
+		assert.EqualValues(t, 1, round.Rejected)
 	}
 }
 

--- a/ledger_test.go
+++ b/ledger_test.go
@@ -46,10 +46,6 @@ func TestLedger_BroadcastNop(t *testing.T) {
 			txsLock.Lock()
 			txs = append(txs, tx)
 			txsLock.Unlock()
-
-			// Somehow this prevents AddTransaction from
-			// returning ErrMissingParents
-			time.Sleep(time.Nanosecond * 1)
 		}
 	}()
 

--- a/ledger_test.go
+++ b/ledger_test.go
@@ -77,13 +77,6 @@ func TestLedger_BroadcastNop(t *testing.T) {
 				currRound.Index,
 				alice.ledger.Graph().RootDepth())
 
-			if currRound.Rejected > 0 {
-				t.Fatal("no tx should be rejected")
-			}
-			if currRound.Ignored > 0 {
-				t.Fatal("no tx should be ignored")
-			}
-
 			if currRound.Index-prevRound > 1 {
 				t.Fatal("more than 1 round finalized")
 			}
@@ -126,12 +119,6 @@ func TestLedger_AddTransaction(t *testing.T) {
 	current := alice.ledger.Rounds().Latest()
 	if current.Index-start > 1 {
 		t.Fatal("more than 1 round finalized")
-	}
-	if current.Rejected > 0 {
-		t.Fatal("no tx should be rejected")
-	}
-	if current.Ignored > 0 {
-		t.Fatal("no tx should be ignored")
 	}
 }
 
@@ -197,10 +184,6 @@ func TestLedger_PayInsufficientBalance(t *testing.T) {
 	for _, node := range testnet.Nodes() {
 		assert.EqualValues(t, aliceBalance, node.BalanceOfAccount(alice))
 		assert.EqualValues(t, 100, node.BalanceOfAccount(bob))
-
-		// All nodes should have rejected the tx
-		round := node.ledger.Rounds().Latest()
-		assert.EqualValues(t, 1, round.Rejected)
 	}
 }
 

--- a/protocol.go
+++ b/protocol.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+
 	"github.com/perlin-network/wavelet/log"
 	"github.com/perlin-network/wavelet/sys"
 	"github.com/pkg/errors"
@@ -50,7 +51,7 @@ func (p *Protocol) Gossip(stream Wavelet_GossipServer) error {
 				continue
 			}
 
-			if err := p.ledger.AddTransaction(tx); err != nil && errors.Cause(err) != ErrMissingParents {
+			if err := p.ledger.addTransaction(tx); err != nil && errors.Cause(err) != ErrMissingParents {
 				fmt.Printf("error adding incoming tx to graph [%v]: %+v\n", err, tx)
 			}
 		}

--- a/round.go
+++ b/round.go
@@ -41,11 +41,6 @@ type Round struct {
 
 	Applied uint64
 
-	// These are not serialized, and are only used
-	// by the local node
-	Rejected uint64
-	Ignored  uint64
-
 	Start Transaction
 	End   Transaction
 }

--- a/snowball_test.go
+++ b/snowball_test.go
@@ -20,10 +20,11 @@
 package wavelet
 
 import (
+	"testing"
+
 	"github.com/perlin-network/noise/skademlia"
 	"github.com/perlin-network/wavelet/sys"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestNewSnowball(t *testing.T) {
@@ -39,8 +40,8 @@ func TestNewSnowball(t *testing.T) {
 	endA := AttachSenderToTransaction(keys, NewTransaction(keys, sys.TagStake, nil))
 	endB := AttachSenderToTransaction(keys, NewTransaction(keys, sys.TagContract, nil))
 
-	a := NewRound(1, ZeroMerkleNodeID, 1337, start, endA)
-	b := NewRound(1, ZeroMerkleNodeID, 1010, start, endB)
+	a := NewRound(1, ZeroMerkleNodeID, 1337, 42, 69, start, endA)
+	b := NewRound(1, ZeroMerkleNodeID, 1010, 12, 34, start, endB)
 
 	// Check that Snowball terminates properly given unanimous sampling of Round A.
 

--- a/snowball_test.go
+++ b/snowball_test.go
@@ -40,8 +40,8 @@ func TestNewSnowball(t *testing.T) {
 	endA := AttachSenderToTransaction(keys, NewTransaction(keys, sys.TagStake, nil))
 	endB := AttachSenderToTransaction(keys, NewTransaction(keys, sys.TagContract, nil))
 
-	a := NewRound(1, ZeroMerkleNodeID, 1337, 42, 69, start, endA)
-	b := NewRound(1, ZeroMerkleNodeID, 1010, 12, 34, start, endB)
+	a := NewRound(1, ZeroMerkleNodeID, 1337, start, endA)
+	b := NewRound(1, ZeroMerkleNodeID, 1010, start, endB)
 
 	// Check that Snowball terminates properly given unanimous sampling of Round A.
 

--- a/testutil.go
+++ b/testutil.go
@@ -53,9 +53,86 @@ func (n *TestNetwork) AddNode(t testing.TB, startingBalance uint64) *TestLedger 
 	return node
 }
 
+func (n *TestNetwork) Nodes() []*TestLedger {
+	return append(n.nodes, n.faucet)
+}
+
+// WaitForRound waits for all the nodes in the network to
+// reach the specified round.
+func (n *TestNetwork) WaitForRound(t testing.TB, round uint64) {
+	if len(n.nodes) == 0 {
+		return
+	}
+
+	done := make(chan struct{})
+	go func() {
+		for _, node := range n.nodes {
+			for ri := range node.WaitForRound(round) {
+				if ri == round {
+					break
+				}
+			}
+		}
+
+		close(done)
+	}()
+
+	select {
+	case <-time.After(time.Second * 10):
+		t.Fatal("timed out waiting for round")
+
+	case <-done:
+		return
+	}
+}
+
 func (n *TestNetwork) WaitForConsensus(t testing.TB) {
-	all := append(n.nodes, n.faucet)
-	TestWaitForConsensus(t, time.Second*30, all)
+	if len(n.nodes) == 0 {
+		return
+	}
+
+	done := make(chan struct{})
+	go func() {
+		first := n.nodes[0]
+		round := <-first.WaitForConsensus()
+
+		for i := 1; i < len(n.nodes); i++ {
+			<-n.nodes[i].WaitForRound(round)
+		}
+
+		close(done)
+	}()
+
+	select {
+	case <-time.After(time.Second * 10):
+		t.Fatal("timed out waiting for consensus")
+
+	case <-done:
+		return
+	}
+}
+
+// WaitForLatestConsensus waits until all nodes
+// have reach the latest consensus round.
+func (n *TestNetwork) WaitForLatestConsensus(t testing.TB) {
+	if len(n.nodes) == 0 {
+		return
+	}
+
+	first := n.nodes[0]
+	current := first.RoundIndex()
+	for round := range first.WaitForConsensus() {
+		if round == 0 {
+			continue
+		}
+
+		if round == current {
+			break
+		}
+		current = round
+	}
+
+	n.WaitForRound(t, current)
 }
 
 type TestLedger struct {
@@ -172,22 +249,39 @@ func (l *TestLedger) Reward() uint64 {
 	return reward
 }
 
-func (l *TestLedger) WaitForConsensus() <-chan bool {
-	ch := make(chan bool)
+func (l *TestLedger) RoundIndex() uint64 {
+	return l.ledger.Rounds().Latest().Index
+}
+
+// WaitForConsensus waits until the node has advanced
+// by at least 1 consensus round.
+func (l *TestLedger) WaitForConsensus() <-chan uint64 {
+	return l.WaitForRound(l.ledger.Rounds().Latest().Index + 1)
+}
+
+// WaitForRound waits until the node reaches the specified round index.
+func (l *TestLedger) WaitForRound(index uint64) <-chan uint64 {
+	ch := make(chan uint64, 1)
 	go func() {
-		start := l.ledger.Rounds().Latest()
+		defer close(ch)
+
+		if current := l.ledger.Rounds().Latest().Index; current >= index {
+			ch <- current
+			return
+		}
+
 		timeout := time.NewTimer(time.Second * 3)
 		ticker := time.NewTicker(time.Millisecond * 100)
 		for {
 			select {
 			case <-timeout.C:
-				ch <- false
+				ch <- 0
 				return
 
 			case <-ticker.C:
 				current := l.ledger.Rounds().Latest()
-				if current.Index > start.Index {
-					ch <- true
+				if current.Index >= index {
+					ch <- current.Index
 					return
 				}
 			}
@@ -309,4 +403,21 @@ func loadKeys(t testing.TB, wallet string) *skademlia.Keypair {
 	}
 
 	return keys
+}
+
+func waitFor(t testing.TB, err string, fn func() bool) {
+	timeout := time.NewTimer(time.Second * 3)
+	ticker := time.NewTicker(time.Millisecond * 500)
+
+	for {
+		select {
+		case <-timeout.C:
+			t.Fatal(err)
+
+		case <-ticker.C:
+			if !fn() {
+				return
+			}
+		}
+	}
 }

--- a/testutil.go
+++ b/testutil.go
@@ -39,6 +39,16 @@ func (n *TestNetwork) Cleanup() {
 	n.faucet.Cleanup()
 }
 
+func (n *TestNetwork) AddNodeWithWallet(t testing.TB, wallet string) *TestLedger {
+	node := NewTestLedger(t, TestLedgerConfig{
+		Peers:  []string{n.faucet.Addr()},
+		Wallet: wallet,
+	})
+	n.nodes = append(n.nodes, node)
+
+	return node
+}
+
 func (n *TestNetwork) AddNode(t testing.TB, startingBalance uint64) *TestLedger {
 	node := NewTestLedger(t, TestLedgerConfig{
 		Peers: []string{n.faucet.Addr()},

--- a/testutil.go
+++ b/testutil.go
@@ -197,17 +197,6 @@ func (l *TestLedger) WaitForConsensus() <-chan bool {
 	return ch
 }
 
-func (l *TestLedger) Nop() (Transaction, error) {
-	keys := l.ledger.client.Keys()
-	tx := AttachSenderToTransaction(
-		keys,
-		NewTransaction(keys, sys.TagNop, nil),
-		l.ledger.Graph().FindEligibleParents()...)
-
-	err := l.ledger.AddTransaction(tx)
-	return tx, err
-}
-
 func (l *TestLedger) Pay(to *TestLedger, amount uint64) (Transaction, error) {
 	payload := Transfer{
 		Recipient: to.PublicKey(),
@@ -215,13 +204,9 @@ func (l *TestLedger) Pay(to *TestLedger, amount uint64) (Transaction, error) {
 	}
 
 	keys := l.ledger.client.Keys()
-	tx := AttachSenderToTransaction(
-		keys,
-		NewTransaction(keys, sys.TagTransfer, payload.Marshal()),
-		l.ledger.Graph().FindEligibleParents()...)
-
-	err := l.ledger.AddTransaction(tx)
-	return tx, err
+	tx := NewTransaction(keys, sys.TagTransfer, payload.Marshal())
+	l.ledger.QueueTransaction(tx)
+	return tx, nil
 }
 
 func (l *TestLedger) PlaceStake(amount uint64) (Transaction, error) {
@@ -231,13 +216,9 @@ func (l *TestLedger) PlaceStake(amount uint64) (Transaction, error) {
 	}
 
 	keys := l.ledger.client.Keys()
-	tx := AttachSenderToTransaction(
-		keys,
-		NewTransaction(keys, sys.TagStake, payload.Marshal()),
-		l.ledger.Graph().FindEligibleParents()...)
-
-	err := l.ledger.AddTransaction(tx)
-	return tx, err
+	tx := NewTransaction(keys, sys.TagStake, payload.Marshal())
+	l.ledger.QueueTransaction(tx)
+	return tx, nil
 }
 
 func (l *TestLedger) WithdrawStake(amount uint64) (Transaction, error) {
@@ -247,13 +228,9 @@ func (l *TestLedger) WithdrawStake(amount uint64) (Transaction, error) {
 	}
 
 	keys := l.ledger.client.Keys()
-	tx := AttachSenderToTransaction(
-		keys,
-		NewTransaction(keys, sys.TagStake, payload.Marshal()),
-		l.ledger.Graph().FindEligibleParents()...)
-
-	err := l.ledger.AddTransaction(tx)
-	return tx, err
+	tx := NewTransaction(keys, sys.TagStake, payload.Marshal())
+	l.ledger.QueueTransaction(tx)
+	return tx, nil
 }
 
 func (l *TestLedger) WithdrawReward(amount uint64) (Transaction, error) {
@@ -263,13 +240,9 @@ func (l *TestLedger) WithdrawReward(amount uint64) (Transaction, error) {
 	}
 
 	keys := l.ledger.client.Keys()
-	tx := AttachSenderToTransaction(
-		keys,
-		NewTransaction(keys, sys.TagStake, payload.Marshal()),
-		l.ledger.Graph().FindEligibleParents()...)
-
-	err := l.ledger.AddTransaction(tx)
-	return tx, err
+	tx := NewTransaction(keys, sys.TagStake, payload.Marshal())
+	l.ledger.QueueTransaction(tx)
+	return tx, nil
 }
 
 func (l *TestLedger) FindTransaction(t testing.TB, id TransactionID) *Transaction {

--- a/tx_applier_test.go
+++ b/tx_applier_test.go
@@ -70,7 +70,7 @@ func TestApplyTransaction_Single(t *testing.T) {
 
 	rng := rand.New(rand.NewSource(42))
 
-	round := NewRound(viewID, state.Checksum(), 0, Transaction{}, initialRoot)
+	round := NewRound(viewID, state.Checksum(), 0, 0, 0, Transaction{}, initialRoot)
 
 	for i := 0; i < 10000; i++ {
 		switch rng.Intn(2) {
@@ -150,7 +150,7 @@ func TestApplyTransaction_Collapse(t *testing.T) {
 	assert.NotNil(t, graph)
 
 	rng := rand.New(rand.NewSource(42))
-	round := NewRound(viewID, state.Checksum(), 0, Transaction{}, initialRoot)
+	round := NewRound(viewID, state.Checksum(), 0, 0, 0, Transaction{}, initialRoot)
 
 	accountState := NewAccounts(stateStore)
 	assert.NoError(t, accountState.Commit(state))
@@ -171,7 +171,7 @@ func TestApplyTransaction_Collapse(t *testing.T) {
 			err = accountState.Commit(results.snapshot)
 			assert.NoError(t, err)
 			state = results.snapshot
-			round = NewRound(viewID+1, state.Checksum(), uint64(results.appliedCount), round.End, tx)
+			round = NewRound(viewID+1, state.Checksum(), uint64(results.appliedCount), uint64(results.rejectedCount), uint64(results.ignoredCount), round.End, tx)
 			viewID += 1
 
 			for id, account := range accounts {
@@ -187,7 +187,7 @@ func TestApplyTransferTransaction(t *testing.T) {
 	t.Parallel()
 
 	state := avl.New(store.NewInmem())
-	round := NewRound(0, state.Checksum(), 0, Transaction{}, Transaction{})
+	round := NewRound(0, state.Checksum(), 0, 0, 0, Transaction{}, Transaction{})
 	alice, err := skademlia.NewKeys(1, 1)
 	assert.NoError(t, err)
 	bob, err := skademlia.NewKeys(1, 1)
@@ -218,7 +218,7 @@ func TestApplyStakeTransaction(t *testing.T) {
 	t.Parallel()
 
 	state := avl.New(store.NewInmem())
-	round := NewRound(0, state.Checksum(), 0, Transaction{}, Transaction{})
+	round := NewRound(0, state.Checksum(), 0, 0, 0, Transaction{}, Transaction{})
 	account, err := skademlia.NewKeys(1, 1)
 	assert.NoError(t, err)
 
@@ -249,7 +249,7 @@ func TestApplyBatchTransaction(t *testing.T) {
 	t.Parallel()
 
 	state := avl.New(store.NewInmem())
-	round := NewRound(0, state.Checksum(), 0, Transaction{}, Transaction{})
+	round := NewRound(0, state.Checksum(), 0, 0, 0, Transaction{}, Transaction{})
 	alice, err := skademlia.NewKeys(1, 1)
 	assert.NoError(t, err)
 	bob, err := skademlia.NewKeys(1, 1)
@@ -282,7 +282,7 @@ func TestApplyContractTransaction(t *testing.T) {
 	t.Parallel()
 
 	state := avl.New(store.NewInmem())
-	round := NewRound(0, state.Checksum(), 0, Transaction{}, Transaction{})
+	round := NewRound(0, state.Checksum(), 0, 0, 0, Transaction{}, Transaction{})
 	account, err := skademlia.NewKeys(1, 1)
 	assert.NoError(t, err)
 

--- a/tx_applier_test.go
+++ b/tx_applier_test.go
@@ -70,7 +70,7 @@ func TestApplyTransaction_Single(t *testing.T) {
 
 	rng := rand.New(rand.NewSource(42))
 
-	round := NewRound(viewID, state.Checksum(), 0, 0, 0, Transaction{}, initialRoot)
+	round := NewRound(viewID, state.Checksum(), 0, Transaction{}, initialRoot)
 
 	for i := 0; i < 10000; i++ {
 		switch rng.Intn(2) {
@@ -150,7 +150,7 @@ func TestApplyTransaction_Collapse(t *testing.T) {
 	assert.NotNil(t, graph)
 
 	rng := rand.New(rand.NewSource(42))
-	round := NewRound(viewID, state.Checksum(), 0, 0, 0, Transaction{}, initialRoot)
+	round := NewRound(viewID, state.Checksum(), 0, Transaction{}, initialRoot)
 
 	accountState := NewAccounts(stateStore)
 	assert.NoError(t, accountState.Commit(state))
@@ -171,7 +171,7 @@ func TestApplyTransaction_Collapse(t *testing.T) {
 			err = accountState.Commit(results.snapshot)
 			assert.NoError(t, err)
 			state = results.snapshot
-			round = NewRound(viewID+1, state.Checksum(), uint64(results.appliedCount), uint64(results.rejectedCount), uint64(results.ignoredCount), round.End, tx)
+			round = NewRound(viewID+1, state.Checksum(), uint64(results.appliedCount), round.End, tx)
 			viewID += 1
 
 			for id, account := range accounts {
@@ -187,7 +187,7 @@ func TestApplyTransferTransaction(t *testing.T) {
 	t.Parallel()
 
 	state := avl.New(store.NewInmem())
-	round := NewRound(0, state.Checksum(), 0, 0, 0, Transaction{}, Transaction{})
+	round := NewRound(0, state.Checksum(), 0, Transaction{}, Transaction{})
 	alice, err := skademlia.NewKeys(1, 1)
 	assert.NoError(t, err)
 	bob, err := skademlia.NewKeys(1, 1)
@@ -218,7 +218,7 @@ func TestApplyStakeTransaction(t *testing.T) {
 	t.Parallel()
 
 	state := avl.New(store.NewInmem())
-	round := NewRound(0, state.Checksum(), 0, 0, 0, Transaction{}, Transaction{})
+	round := NewRound(0, state.Checksum(), 0, Transaction{}, Transaction{})
 	account, err := skademlia.NewKeys(1, 1)
 	assert.NoError(t, err)
 
@@ -249,7 +249,7 @@ func TestApplyBatchTransaction(t *testing.T) {
 	t.Parallel()
 
 	state := avl.New(store.NewInmem())
-	round := NewRound(0, state.Checksum(), 0, 0, 0, Transaction{}, Transaction{})
+	round := NewRound(0, state.Checksum(), 0, Transaction{}, Transaction{})
 	alice, err := skademlia.NewKeys(1, 1)
 	assert.NoError(t, err)
 	bob, err := skademlia.NewKeys(1, 1)
@@ -282,7 +282,7 @@ func TestApplyContractTransaction(t *testing.T) {
 	t.Parallel()
 
 	state := avl.New(store.NewInmem())
-	round := NewRound(0, state.Checksum(), 0, 0, 0, Transaction{}, Transaction{})
+	round := NewRound(0, state.Checksum(), 0, Transaction{}, Transaction{})
 	account, err := skademlia.NewKeys(1, 1)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
```go
paylod := wavelet.Transfer{to.PublicKey(), 1337}
ledger.QueueTransaction(wavelet.NewTransaction(keys, sys.TagTransfer, payload.Marshal()))
```

Changes:
- `AddTransaction` is replaced with `QueueTransaction`, which is only used for adding new transaction by the sender into the ledger
- Don't export `AddTransaction` and `BroadcastNop`, as they are only meant to be used internally within Wavelet (e.g. CLI and API should use `QueueTransaction` instead)
- Queue transactions are added to the ledger in the `FinalizeRounds` goroutine

TODO:

- [x] `QueueTransaction` should wait until the transaction is added to the ledger (e.g. CLI and API)
- [x] Check if queue is full
- [x] Turn errors returned by `QueueTransaction` into constants
- [x] Add some tests from #142 just to be safe
- [x] Check no tx is ignored or rejected in test