### PR TITLE
ledger: add test to ensure no tx are ignored when 1 node spams the network

### DIFF
--- a/ledger_test.go
+++ b/ledger_test.go
@@ -104,6 +104,54 @@ func TestLedger_BroadcastNop(t *testing.T) {
 	}
 }
 
+func TestLedger_Ignore(t *testing.T) {
+	testnet := NewTestNetwork(t)
+	defer testnet.Cleanup()
+
+	alice := testnet.faucet
+	bob := testnet.AddNodeWithWallet(t, "85e7450f7cf0d9cd1d1d7bf4169c2f364eea4ba833a7280e0f931a1d92fd92c2696937c2c8df35dba0169de72990b80761e51dd9e2411fa1fce147f68ade830a")
+	charlie := testnet.AddNodeWithWallet(t, "5b9fcd2d6f8e34f4aa472e0c3099fefd25f0ceab9e908196b1dda63e55349d22f03bb6f98c4dfd31f3d448c7ec79fa3eaa92250112ada43471812f4b1ace6467")
+
+	go func() {
+		for {
+			_, err := alice.PlaceStake(1)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+	}()
+
+	go func() {
+		for {
+			ri := <-charlie.WaitForRound(5)
+			if ri >= 5 {
+				break
+			}
+		}
+
+		fmt.Println("charlie: ps 100")
+		_, err := charlie.PlaceStake(100)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	for {
+		ri := <-bob.WaitForConsensus()
+		<-alice.WaitForRound(ri)
+		<-charlie.WaitForRound(ri)
+
+		round := bob.ledger.Rounds().Latest()
+		fmt.Printf("round: %d, applied: %d, rejected: %d, ignored: %d, alice stake: %d, charlie stake: %d\n",
+			round.Index, round.Applied, round.Rejected, round.Ignored,
+			alice.Stake(), charlie.Stake())
+
+		if round.Ignored > 0 {
+			t.Fatal("no tx should be ignored")
+		}
+	}
+}
+
 func TestLedger_AddTransaction(t *testing.T) {
 	testnet := NewTestNetwork(t)
 	defer testnet.Cleanup()


### PR DESCRIPTION
To reproduce, run `TestLedger_Ignore`:

```sh
$ go run -v -count=1 . -run TestLedger_Ignore
```

Sample run:
```
round: 1, applied: 440, rejected: 0, ignored: 0, alice stake: 440, charlie stake: 0
round: 2, applied: 209, rejected: 0, ignored: 0, alice stake: 649, charlie stake: 0
round: 3, applied: 119, rejected: 0, ignored: 0, alice stake: 768, charlie stake: 0
round: 4, applied: 127, rejected: 0, ignored: 0, alice stake: 895, charlie stake: 0
charlie: ps 100
round: 5, applied: 233, rejected: 0, ignored: 0, alice stake: 1128, charlie stake: 0
round: 6, applied: 97, rejected: 0, ignored: 1, alice stake: 1225, charlie stake: 0
--- FAIL: TestLedger_Ignore (5.42s)
    ledger_test.go:150: no tx should be ignored
```

What the test does is it sets up a network with 3 nodes (using the default genesis), named Alice, Bob, and Charlie. Alice is set to spam the network with `PlaceStake` transactions. Charlie is set to send a single `PlaceStake` transaction once round 5 is reached. Bob is the observer.

What is supposed to happen is that all of Alice's and Charlie's transactions are applied. But what happens instead is that after Charlie sends a transaction, his transaction will be ignored. Somehow there is at least 1 transaction ignored (sometimes there are more than 1, but Charlie's transaction will always be one of the transactions ignored).