### PR TITLE
Fixed /accounts not plural.

### DIFF
--- a/site/docs/api.md
+++ b/site/docs/api.md
@@ -77,7 +77,7 @@ Get Account Information
 
 * **URL**
 
-    `/account/:id`
+    `/accounts/:id`
 
 * **Method:**
 


### PR DESCRIPTION
Before, `/account/:id` according to the docs would return a 404 endpoint. This fixes the docs to have `/accounts/:id` which is the correct route.