### PR TITLE
fix: update example contract docs

### DIFF
--- a/site/docs/smart-contracts.md
+++ b/site/docs/smart-contracts.md
@@ -45,8 +45,8 @@ lto = true
 crate-type = ["cdylib"]
 
 [dependencies]
-smart-contract = "0.1.0"
-smart-contract-macros = "0.1.0"
+smart-contract = "0.2.0"
+smart-contract-macros = "0.2.0"
 ```
 
 Open up `src/lib.rs` and paste the code below. What our first smart contract will do is that whenever the


### PR DESCRIPTION
Currently the example uses the old `smart-contracts` crate and therefore doesn't work. This should fix it