### PR TITLE
resolver: write heap pprof to disk upon oom

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -122,8 +122,8 @@ LOOP:
 							crashFile := fmt.Sprintf("%s/heap-%s.pprof", crashDir, crashTimestamp)
 
 							if heapFile, err := os.Create(crashFile); err == nil {
-								defer heapFile.Close()
 								_ = pprof.Lookup("heap").WriteTo(heapFile, 0)
+								heapFile.Close()
 							}
 						}
 

--- a/recovery.go
+++ b/recovery.go
@@ -109,7 +109,6 @@ LOOP:
 					var memStats runtime.MemStats
 					runtime.ReadMemStats(&memStats)
 
-
 					if memStats.Alloc > 1048576*d.config.MaxMemoryMB {
 						d.delegate.prepareShutdown(d.mu, errors.New("Memory usage exceeded maximum. Node is scheduled to shutdown now."))
 

--- a/recovery.go
+++ b/recovery.go
@@ -109,7 +109,6 @@ LOOP:
 					var memStats runtime.MemStats
 					runtime.ReadMemStats(&memStats)
 
-logger.Debug().Msgf("memStats.Alloc = %v, 1048576*d.config.MaxMemoryMB = %v", memStats.Alloc, 1048576*d.config.MaxMemoryMB)
 
 					if memStats.Alloc > 1048576*d.config.MaxMemoryMB {
 						d.delegate.prepareShutdown(d.mu, errors.New("Memory usage exceeded maximum. Node is scheduled to shutdown now."))


### PR DESCRIPTION
When the stall detector detects excessive memory usage, also write a binary heap dump