### PR TITLE
Reduce memory allocations in contract VM caching, increase max number of memory pages per contract, and temporarily remove consensus invariant checks in the stall detector.

### DIFF
--- a/collapse.go
+++ b/collapse.go
@@ -217,7 +217,7 @@ func collapseTransactions(g *Graph, accounts *Accounts, round uint64, current *R
 	res.rejected = make([]*Transaction, 0, order.Len())
 	res.rejectedErrors = make([]error, 0, order.Len())
 
-	ctx := NewApplyContext()
+	ctx := NewCollapseContext()
 
 	// Apply transactions in reverse order from the end of the round
 	// all the way down to the beginning of the round.
@@ -272,12 +272,7 @@ func collapseTransactions(g *Graph, accounts *Accounts, round uint64, current *R
 		processRewardWithdrawals(round, res.snapshot)
 	}
 
-	for _, id := range ctx.ContractIDs {
-		vm := ctx.ContractVMs[id]
-
-		SaveContractMemorySnapshot(res.snapshot, id, vm.Memory)
-		SaveContractGlobals(res.snapshot, id, vm.Globals)
-	}
+	ctx.Flush(res.snapshot)
 
 	return res, nil
 }

--- a/ledger.go
+++ b/ledger.go
@@ -195,12 +195,9 @@ func NewLedger(kv store.KV, client *skademlia.Client, opts ...Option) *Ledger {
 	stallDetector = NewStallDetector(stop, StallDetectorConfig{
 		MaxMemoryMB: cfg.MaxMemoryMB,
 	}, StallDetectorDelegate{
-		Ping: func() {
-			stallDetector.ReportNetworkActivity() // TODO: Real pings.
-		},
 		PrepareShutdown: func(err error) {
 			logger := log.Node()
-			logger.Error().Err(err).Msg("PrepareShutdown")
+			logger.Error().Err(err).Msg("Shutting down node...")
 		},
 	})
 	go stallDetector.Run()
@@ -781,8 +778,6 @@ FINALIZE_ROUNDS:
 							return
 						}
 
-						l.stallDetector.ReportIncomingRound(round.ID)
-
 						voteChan <- vote{voter: voter, value: &round}
 					}
 
@@ -893,8 +888,6 @@ FINALIZE_ROUNDS:
 			Hex("old_merkle_root", current.Merkle[:]).
 			Uint64("round_depth", preferred.End.Depth-preferred.Start.Depth).
 			Msg("Finalized consensus round, and initialized a new round.")
-
-		l.stallDetector.ReportFinalizedRound(preferred.ID)
 
 		//go ExportGraphDOT(finalized, contractIDs.graph)
 	}

--- a/recovery.go
+++ b/recovery.go
@@ -3,7 +3,6 @@ package wavelet
 import (
 	"fmt"
 	"github.com/perlin-network/wavelet/log"
-	"github.com/perlin-network/wavelet/lru"
 	"github.com/pkg/errors"
 	"os"
 	"runtime"
@@ -17,14 +16,6 @@ type StallDetector struct {
 	stop     <-chan struct{}
 	config   StallDetectorConfig
 	delegate StallDetectorDelegate
-
-	// Network statistics.
-	lastNetworkActivityTime time.Time
-
-	// Round statistics.
-	roundSet             *lru.LRU // RoundID -> struct{}
-	lastRoundTime        time.Time
-	lastFinalizationTime time.Time
 }
 
 type StallDetectorConfig struct {
@@ -32,14 +23,7 @@ type StallDetectorConfig struct {
 }
 
 type StallDetectorDelegate struct {
-	Ping            func()
 	PrepareShutdown func(error)
-}
-
-func (d StallDetectorDelegate) ping(mu *sync.Mutex) {
-	mu.Unlock()
-	d.Ping()
-	mu.Lock()
 }
 
 func (d StallDetectorDelegate) prepareShutdown(mu *sync.Mutex, err error) {
@@ -50,19 +34,15 @@ func (d StallDetectorDelegate) prepareShutdown(mu *sync.Mutex, err error) {
 
 func NewStallDetector(stop <-chan struct{}, config StallDetectorConfig, delegate StallDetectorDelegate) *StallDetector {
 	return &StallDetector{
-		mu:                      &sync.Mutex{},
-		stop:                    stop,
-		config:                  config,
-		delegate:                delegate,
-		lastNetworkActivityTime: time.Now(),
-		roundSet:                lru.NewLRU(4),
-		lastRoundTime:           time.Now(),
-		lastFinalizationTime:    time.Now(),
+		mu:       &sync.Mutex{},
+		stop:     stop,
+		config:   config,
+		delegate: delegate,
 	}
 }
 
 func (d *StallDetector) Run() {
-	ticker := time.NewTicker(10 * time.Second)
+	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 
 	logger := log.Node()
@@ -71,39 +51,9 @@ LOOP:
 	for {
 		select {
 		case <-ticker.C:
-			currentTime := time.Now()
-
-			hasNetworkActivityRecently := false
-
 			func() {
 				d.mu.Lock()
 				defer d.mu.Unlock()
-
-				if currentTime.After(d.lastNetworkActivityTime) {
-					if currentTime.Sub(d.lastNetworkActivityTime) > 120*time.Second {
-						d.delegate.prepareShutdown(d.mu, errors.New("We did not detect any network activity during the last 2 minutes, and our Ping requests have got no responses. Node is scheduled to shutdown now."))
-
-						if err := d.tryRestart(); err != nil {
-							logger.Error().Err(err).Msg("Failed to restart process")
-						}
-
-						return // Restarting process is impossible. Stop running the stall detector.
-					} else if currentTime.Sub(d.lastNetworkActivityTime) > 60*time.Second {
-						d.delegate.ping(d.mu)
-					} else {
-						hasNetworkActivityRecently = true
-					}
-				}
-
-				if currentTime.After(d.lastFinalizationTime) && currentTime.After(d.lastRoundTime) && currentTime.Sub(d.lastRoundTime) > 180*time.Second && hasNetworkActivityRecently {
-					d.delegate.prepareShutdown(d.mu, errors.New("Seems that consensus has stalled. Node is scheduled to shutdown now."))
-
-					if err := d.tryRestart(); err != nil {
-						logger.Error().Err(err).Msg("Failed to restart process")
-					}
-
-					return
-				}
 
 				if d.config.MaxMemoryMB > 0 {
 					var memStats runtime.MemStats
@@ -172,27 +122,4 @@ LOOP:
 			break LOOP
 		}
 	}
-}
-
-func (d *StallDetector) ReportNetworkActivity() {
-	d.mu.Lock()
-	d.lastNetworkActivityTime = time.Now()
-	d.mu.Unlock()
-}
-
-func (d *StallDetector) ReportIncomingRound(roundID RoundID) {
-	d.mu.Lock()
-	if d.roundSet != nil {
-		if _, loaded := d.roundSet.LoadOrPut(roundID, struct{}{}); !loaded {
-			d.lastRoundTime = time.Now()
-		}
-	}
-	d.mu.Unlock()
-}
-
-func (d *StallDetector) ReportFinalizedRound(roundID RoundID) {
-	d.mu.Lock()
-	d.roundSet = lru.NewLRU(4)
-	d.lastRoundTime = time.Now()
-	d.mu.Unlock()
 }

--- a/sys/const.go
+++ b/sys/const.go
@@ -47,7 +47,7 @@ var (
 	// Snowball consensus protocol parameters.
 	SnowballK     = 2
 	SnowballAlpha = 0.8
-	SnowballBeta  = 150
+	SnowballBeta  = 50
 
 	// Timeout for querying a transaction to K peers.
 	QueryTimeout = 1 * time.Second
@@ -277,7 +277,7 @@ var (
 	}
 
 	ContractDefaultMemoryPages = 4
-	ContractMaxMemoryPages     = 32
+	ContractMaxMemoryPages     = 4096
 	ContractTableSize          = 4096
 	ContractMaxValueSlots      = 8192
 	ContractMaxCallStackDepth  = 256

--- a/tx_applier.go
+++ b/tx_applier.go
@@ -24,6 +24,7 @@ import (
 	wasm "github.com/perlin-network/life/wasm-validation"
 	"github.com/perlin-network/wavelet/avl"
 	"github.com/perlin-network/wavelet/log"
+	"github.com/perlin-network/wavelet/lru"
 	"github.com/perlin-network/wavelet/sys"
 	"github.com/pkg/errors"
 )
@@ -32,63 +33,49 @@ type contractExecutorState struct {
 	GasPayer      AccountID
 	GasLimit      uint64
 	GasLimitIsSet bool
-	ApplyCtx      *ApplyContext
+	Context       *CollapseContext
 }
 
-type state struct {
-	contractID AccountID
-	vm         *VMState
+type CollapseContext struct {
+	ContractVMs map[AccountID]*VMState
+	ContractIDs []AccountID // contract ids to preserve order of state insertions
+
+	VMCache *lru.LRU
 }
 
-type ApplyContext struct {
-	contractVMStates map[AccountID]*VMState
-	contractIDs      []AccountID // contract ids to preserve order of state insertions
-}
-
-func NewApplyContext() *ApplyContext {
-	return &ApplyContext{
-		contractVMStates: make(map[AccountID]*VMState),
+func NewApplyContext() *CollapseContext {
+	return &CollapseContext{
+		ContractVMs: make(map[AccountID]*VMState),
+		VMCache:     lru.NewLRU(4),
 	}
 }
 
-func (ac *ApplyContext) AddState(contractID AccountID, state *VMState) {
-	if _, ok := ac.contractVMStates[contractID]; !ok {
-		ac.contractVMStates[contractID] = state
-		ac.contractIDs = append(ac.contractIDs, contractID)
+func (ac *CollapseContext) AddState(contractID AccountID, state *VMState) {
+	if _, ok := ac.ContractVMs[contractID]; !ok {
+		ac.ContractVMs[contractID] = state
+		ac.ContractIDs = append(ac.ContractIDs, contractID)
 	}
 }
 
-func (ac *ApplyContext) GetState(contractID AccountID) (*VMState, bool) {
-	vm, exists := ac.contractVMStates[contractID]
+func (ac *CollapseContext) GetContractState(contractID AccountID) (*VMState, bool) {
+	vm, exists := ac.ContractVMs[contractID]
 	return vm, exists
 }
 
-func (ac *ApplyContext) States() []*state {
-	states := make([]*state, 0, len(ac.contractIDs))
-	for _, id := range ac.contractIDs {
-		states = append(states, &state{
-			contractID: id,
-			vm:         ac.contractVMStates[id],
-		})
-	}
-
-	return states
-}
-
-func ApplyTransaction(round *Round, state *avl.Tree, tx *Transaction, applyCtx *ApplyContext) error {
+func ApplyTransaction(round *Round, state *avl.Tree, tx *Transaction, ctx *CollapseContext) error {
 	return applyTransaction(round, state, tx, &contractExecutorState{
 		GasPayer: tx.Creator,
-		ApplyCtx: applyCtx,
+		Context:  ctx,
 	})
 }
 
-func applyTransaction(round *Round, state *avl.Tree, tx *Transaction, execState *contractExecutorState) error {
+func applyTransaction(round *Round, state *avl.Tree, tx *Transaction, executorState *contractExecutorState) error {
 	original := state.Snapshot()
 
 	switch tx.Tag {
 	case sys.TagNop:
 	case sys.TagTransfer:
-		if err := applyTransferTransaction(state, round, tx, execState); err != nil {
+		if err := applyTransferTransaction(state, round, tx, executorState); err != nil {
 			state.Revert(original)
 			return errors.Wrap(err, "could not apply transfer transaction")
 		}
@@ -98,12 +85,12 @@ func applyTransaction(round *Round, state *avl.Tree, tx *Transaction, execState 
 			return errors.Wrap(err, "could not apply stake transaction")
 		}
 	case sys.TagContract:
-		if err := applyContractTransaction(state, round, tx, execState); err != nil {
+		if err := applyContractTransaction(state, round, tx, executorState); err != nil {
 			state.Revert(original)
 			return errors.Wrap(err, "could not apply contract transaction")
 		}
 	case sys.TagBatch:
-		if err := applyBatchTransaction(state, round, tx, execState); err != nil {
+		if err := applyBatchTransaction(state, round, tx, executorState); err != nil {
 			state.Revert(original)
 			return errors.Wrap(err, "could not apply batch transaction")
 		}
@@ -341,14 +328,14 @@ func executeContractInTransactionContext(
 	var vmState *VMState
 	var vmStateLoaded bool
 
-	if state.ApplyCtx != nil {
-		vmState, vmStateLoaded = state.ApplyCtx.GetState(contractID)
+	if state.Context != nil {
+		vmState, vmStateLoaded = state.Context.GetContractState(contractID)
 		if !vmStateLoaded {
 			vmState = &VMState{}
 		}
 	}
 
-	invocationErr := executor.Execute(snapshot, contractID, round, tx, amount, realGasLimit, string(funcName), funcParams, code, vmState, vmStateLoaded)
+	invocationErr := executor.Execute(snapshot, contractID, round, tx, amount, realGasLimit, string(funcName), funcParams, code, state.Context, vmState, vmStateLoaded)
 
 	// availableBalance >= realGasLimit >= executor.Gas && state.GasLimit >= realGasLimit must always hold.
 	if realGasLimit < executor.Gas {
@@ -382,9 +369,8 @@ func executeContractInTransactionContext(
 				Msg("Exceeded gas limit while invoking smart contract function.")
 		}
 	} else {
-		// Contract invocation succeeded. VM state can be safely saved now.
-		if vmState != nil {
-			state.ApplyCtx.AddState(contractID, vmState)
+		if vmState != nil { // Contract invocation succeeded. VM state can be safely saved now.
+			state.Context.AddState(contractID, vmState)
 		}
 
 		if executor.Gas > contractGasBalance {

--- a/tx_applier_test.go
+++ b/tx_applier_test.go
@@ -52,6 +52,7 @@ func TestApplyTransaction_Single(t *testing.T) {
 
 	accounts := make(map[AccountID]*testAccount)
 	accountIDs := make([]AccountID, 0)
+
 	for i := 0; i < 60; i++ {
 		keys, err := skademlia.NewKeys(1, 1)
 		assert.NoError(t, err)
@@ -72,21 +73,25 @@ func TestApplyTransaction_Single(t *testing.T) {
 
 	round := NewRound(viewID, state.Checksum(), 0, Transaction{}, initialRoot)
 
+	ctx := NewCollapseContext()
+
 	for i := 0; i < 10000; i++ {
 		switch rng.Intn(2) {
 		case 0:
 			amount := rng.Uint64()%100 + 1
+
 			account := accounts[accountIDs[rng.Intn(len(accountIDs))]]
 			account.effect.Stake += amount
 			account.effect.Balance -= amount
 
 			tx := AttachSenderToTransaction(account.keys, NewTransaction(account.keys, sys.TagStake, buildPlaceStakePayload(amount).Marshal()))
-			err := ApplyTransaction(&round, state, &tx, nil)
-			assert.NoError(t, err)
+			assert.NoError(t, ApplyTransaction(&round, state, &tx, ctx))
 		case 1:
 			amount := rng.Uint64()%100 + 1
+
 			fromAccount := accounts[accountIDs[rng.Intn(len(accountIDs))]]
 			toAccount := accounts[accountIDs[rng.Intn(len(accountIDs))]]
+
 			if fromAccount.keys.PublicKey() == toAccount.keys.PublicKey() {
 				continue
 			}
@@ -97,13 +102,13 @@ func TestApplyTransaction_Single(t *testing.T) {
 			toAccount.effect.Balance += amount
 
 			tx := AttachSenderToTransaction(fromAccount.keys, NewTransaction(fromAccount.keys, sys.TagTransfer, buildTransferPayload(toAccountID, amount).Marshal()))
-			err := ApplyTransaction(&round, state, &tx, nil)
-			assert.NoError(t, err)
+			assert.NoError(t, ApplyTransaction(&round, state, &tx, ctx))
 		default:
 			panic("unreachable")
 		}
-
 	}
+
+	ctx.Flush(state)
 
 	for id, account := range accounts {
 		stake, _ := ReadAccountStake(state, id)
@@ -188,6 +193,7 @@ func TestApplyTransferTransaction(t *testing.T) {
 
 	state := avl.New(store.NewInmem())
 	round := NewRound(0, state.Checksum(), 0, Transaction{}, Transaction{})
+
 	alice, err := skademlia.NewKeys(1, 1)
 	assert.NoError(t, err)
 	bob, err := skademlia.NewKeys(1, 1)
@@ -196,22 +202,21 @@ func TestApplyTransferTransaction(t *testing.T) {
 	aliceID := alice.PublicKey()
 	bobID := bob.PublicKey()
 
+	ctx := NewCollapseContext()
+
 	// Case 1 - Success
 	WriteAccountBalance(state, aliceID, 1)
 
 	tx := AttachSenderToTransaction(alice, NewTransaction(alice, sys.TagTransfer, buildTransferPayload(bobID, 1).Marshal()))
-	err = ApplyTransaction(&round, state, &tx, nil)
-	assert.NoError(t, err)
+	assert.NoError(t, ApplyTransaction(&round, state, &tx, ctx))
 
 	// Case 2 - Not enough balance
 	tx = AttachSenderToTransaction(alice, NewTransaction(alice, sys.TagTransfer, buildTransferPayload(bobID, 1).Marshal()))
-	err = ApplyTransaction(&round, state, &tx, nil)
-	assert.Error(t, err)
+	assert.Error(t, ApplyTransaction(&round, state, &tx, ctx))
 
 	// Case 3 - Self-transfer without enough balance
 	tx = AttachSenderToTransaction(alice, NewTransaction(alice, sys.TagTransfer, buildTransferPayload(aliceID, 1).Marshal()))
-	err = ApplyTransaction(&round, state, &tx, nil)
-	assert.Error(t, err)
+	assert.Error(t, ApplyTransaction(&round, state, &tx, ctx))
 }
 
 func TestApplyStakeTransaction(t *testing.T) {
@@ -219,27 +224,29 @@ func TestApplyStakeTransaction(t *testing.T) {
 
 	state := avl.New(store.NewInmem())
 	round := NewRound(0, state.Checksum(), 0, Transaction{}, Transaction{})
+
 	account, err := skademlia.NewKeys(1, 1)
 	assert.NoError(t, err)
 
 	accountID := account.PublicKey()
 
+	ctx := NewCollapseContext()
+
 	// Case 1 - Placement success
 	WriteAccountBalance(state, accountID, 100)
 
 	tx := AttachSenderToTransaction(account, NewTransaction(account, sys.TagStake, buildPlaceStakePayload(100).Marshal()))
-	err = ApplyTransaction(&round, state, &tx, nil)
-	assert.NoError(t, err)
+	assert.NoError(t, ApplyTransaction(&round, state, &tx, ctx))
 
 	// Case 2 - Not enough balance
 	tx = AttachSenderToTransaction(account, NewTransaction(account, sys.TagStake, buildPlaceStakePayload(100).Marshal()))
-	err = ApplyTransaction(&round, state, &tx, nil)
-	assert.Error(t, err)
+	assert.Error(t, ApplyTransaction(&round, state, &tx, ctx))
 
 	// Case 3 - Withdrawal success
 	tx = AttachSenderToTransaction(account, NewTransaction(account, sys.TagStake, buildWithdrawStakePayload(100).Marshal()))
-	err = ApplyTransaction(&round, state, &tx, nil)
-	assert.NoError(t, err)
+	assert.NoError(t, ApplyTransaction(&round, state, &tx, ctx))
+
+	ctx.Flush(state)
 
 	finalBalance, _ := ReadAccountBalance(state, accountID)
 	assert.Equal(t, finalBalance, uint64(100))
@@ -250,6 +257,7 @@ func TestApplyBatchTransaction(t *testing.T) {
 
 	state := avl.New(store.NewInmem())
 	round := NewRound(0, state.Checksum(), 0, Transaction{}, Transaction{})
+
 	alice, err := skademlia.NewKeys(1, 1)
 	assert.NoError(t, err)
 	bob, err := skademlia.NewKeys(1, 1)
@@ -258,21 +266,24 @@ func TestApplyBatchTransaction(t *testing.T) {
 	aliceID := alice.PublicKey()
 	bobID := bob.PublicKey()
 
+	ctx := NewCollapseContext()
+
 	WriteAccountBalance(state, aliceID, 100)
 
 	// initial stake
 	tx := AttachSenderToTransaction(alice, NewTransaction(alice, sys.TagStake, buildPlaceStakePayload(100).Marshal()))
-	err = ApplyTransaction(&round, state, &tx, nil)
+	err = ApplyTransaction(&round, state, &tx, ctx)
 	assert.NoError(t, err)
 
 	// this implies order
 	var batch Batch
-	batch.AddStake(buildWithdrawStakePayload(100))
-	batch.AddTransfer(buildTransferPayload(bobID, 100))
+	assert.NoError(t, batch.AddStake(buildWithdrawStakePayload(100)))
+	assert.NoError(t, batch.AddTransfer(buildTransferPayload(bobID, 100)))
 
 	tx = AttachSenderToTransaction(alice, NewTransaction(alice, sys.TagBatch, batch.Marshal()))
-	err = ApplyTransaction(&round, state, &tx, nil)
-	assert.NoError(t, err)
+	assert.NoError(t, ApplyTransaction(&round, state, &tx, ctx))
+
+	ctx.Flush(state)
 
 	finalBobBalance, _ := ReadAccountBalance(state, bobID)
 	assert.Equal(t, finalBobBalance, uint64(100))
@@ -283,8 +294,11 @@ func TestApplyContractTransaction(t *testing.T) {
 
 	state := avl.New(store.NewInmem())
 	round := NewRound(0, state.Checksum(), 0, Transaction{}, Transaction{})
+
 	account, err := skademlia.NewKeys(1, 1)
 	assert.NoError(t, err)
+
+	ctx := NewCollapseContext()
 
 	accountID := account.PublicKey()
 
@@ -294,34 +308,40 @@ func TestApplyContractTransaction(t *testing.T) {
 	// Case 1 - balance < gas_fee
 	WriteAccountBalance(state, accountID, 99999)
 	tx := AttachSenderToTransaction(account, NewTransaction(account, sys.TagContract, buildContractSpawnPayload(100000, 0, code).Marshal()))
-	err = ApplyTransaction(&round, state, &tx, nil)
-	assert.Error(t, err)
+	assert.Error(t, ApplyTransaction(&round, state, &tx, ctx))
 
 	// Case 2 - Success
 	WriteAccountBalance(state, accountID, 100000)
 	tx = AttachSenderToTransaction(account, NewTransaction(account, sys.TagContract, buildContractSpawnPayload(100000, 0, code).Marshal()))
-	err = ApplyTransaction(&round, state, &tx, nil)
-	assert.NoError(t, err)
+	assert.NoError(t, ApplyTransaction(&round, state, &tx, ctx))
+
+	ctx.Flush(state)
 
 	finalBalance, _ := ReadAccountBalance(state, accountID)
 	assert.Condition(t, func() bool { return finalBalance > 0 && finalBalance < 100000 })
 
-	contractID := AccountID(tx.ID)
+	contractID := tx.ID
 
 	// Try to transfer some money
 	WriteAccountBalance(state, accountID, 1000000000)
 	tx = AttachSenderToTransaction(account, NewTransaction(account, sys.TagTransfer, buildTransferWithInvocationPayload(contractID, 200000000, 500000, []byte("on_money_received"), nil, 0).Marshal()))
-	err = ApplyTransaction(&round, state, &tx, nil)
-	assert.NoError(t, err)
+
+	assert.NoError(t, ApplyTransaction(&round, state, &tx, ctx))
+
+	ctx.Flush(state)
+
 	finalBalance, _ = ReadAccountBalance(state, accountID)
 	assert.True(t, finalBalance > 1000000000-100000000-500000 && finalBalance < 1000000000-100000000)
 
 	// Try to invoke with contract gas balance
 	WriteAccountBalance(state, accountID, 200000000)
 	WriteAccountContractGasBalance(state, contractID, 1000000000)
+
 	tx = AttachSenderToTransaction(account, NewTransaction(account, sys.TagTransfer, buildTransferWithInvocationPayload(contractID, 200000000, 500000, []byte("on_money_received"), nil, 0).Marshal()))
-	err = ApplyTransaction(&round, state, &tx, nil)
-	assert.NoError(t, err)
+	assert.NoError(t, ApplyTransaction(&round, state, &tx, ctx))
+
+	ctx.Flush(state)
+
 	finalBalance, _ = ReadAccountBalance(state, accountID)
 	assert.Equal(t, uint64(100000000), finalBalance)
 	finalGasBalance, _ := ReadAccountContractGasBalance(state, contractID)
@@ -332,8 +352,10 @@ func TestApplyContractTransaction(t *testing.T) {
 	WriteAccountContractGasBalance(state, contractID, 10)
 
 	tx = AttachSenderToTransaction(account, NewTransaction(account, sys.TagTransfer, buildTransferWithInvocationPayload(contractID, 200000000, 500000, []byte("on_money_received"), nil, 0).Marshal()))
+	assert.NoError(t, ApplyTransaction(&round, state, &tx, ctx))
 
-	assert.NoError(t, ApplyTransaction(&round, state, &tx, nil))
+	ctx.Flush(state)
+
 	finalBalance, _ = ReadAccountBalance(state, accountID)
 	assert.True(t, finalBalance > 200000000-500000 && finalBalance < 200000000)
 	finalGasBalance, _ = ReadAccountContractGasBalance(state, contractID)
@@ -342,22 +364,24 @@ func TestApplyContractTransaction(t *testing.T) {
 	// Now it should fail
 	WriteAccountBalance(state, accountID, 200000000)
 	WriteAccountContractGasBalance(state, contractID, 0)
+
 	tx = AttachSenderToTransaction(account, NewTransaction(account, sys.TagTransfer, buildTransferWithInvocationPayload(contractID, 200000000, 500000, []byte("on_money_received"), nil, 0).Marshal()))
-	assert.Error(t, ApplyTransaction(&round, state, &tx, nil))
+	assert.Error(t, ApplyTransaction(&round, state, &tx, ctx))
 
 	code, err = ioutil.ReadFile("testdata/recursive_invocation.wasm")
 	assert.NoError(t, err)
 
 	WriteAccountBalance(state, accountID, 100000000)
 	tx = AttachSenderToTransaction(account, NewTransaction(account, sys.TagContract, buildContractSpawnPayload(100000, 0, code).Marshal()))
-	err = ApplyTransaction(&round, state, &tx, nil)
-	assert.NoError(t, err)
-	recursiveInvocationContractID := AccountID(tx.ID)
+	assert.NoError(t, ApplyTransaction(&round, state, &tx, ctx))
+
+	recursiveInvocationContractID := tx.ID
 
 	WriteAccountBalance(state, accountID, 6000000)
 	tx = AttachSenderToTransaction(account, NewTransaction(account, sys.TagTransfer, buildTransferWithInvocationPayload(recursiveInvocationContractID, 0, 5000000, []byte("bomb"), recursiveInvocationContractID[:], 0).Marshal()))
-	err = ApplyTransaction(&round, state, &tx, nil)
-	assert.NoError(t, err)
+	assert.NoError(t, ApplyTransaction(&round, state, &tx, ctx))
+
+	ctx.Flush(state)
 
 	finalBalance, _ = ReadAccountBalance(state, accountID)
 	assert.True(t, finalBalance >= 1000000 && finalBalance < 2000000) // GasLimit specified in contract is 1000000


### PR DESCRIPTION
contract, collapse: have vm lru cache localized on a per-CollapseContext instance so that the contract vm cache is garbage collected to reduce memory consumption
tx/applier, collapse, contract: rename ApplyContext to CollapseContext and reduce mem allocs iterating through contract vm states ordered map
recovery: have stall detector check every 5 seconds instead of 10 seconds, and remove checking of invariants in network time/consensus stalling
sys: increase max memory pages to 4MB

Removed a global contract VM LRU that was accumulating memory behind-the-scenes, and localized it so that it may be garbage-collected. This reduces a significant amount of overall RAM consumption when several contracts are being spawned up.

I reckon that further memory optimizations may be done by having transaction payloads not kept in-memory, but rather instead be kept on-disk. Similar to what @losfair is working on at the moment.

Until then, runs stably utilizing approx 300MB of RAM after spawning several hundreds of contracts/transfer_back.wasm contracts.

Closes #193.