### PR TITLE
Add support to enable HTTPS on the API server

### DIFF
--- a/api/mod.go
+++ b/api/mod.go
@@ -32,6 +32,7 @@ import (
 	"github.com/perlin-network/wavelet/sys"
 	"github.com/pkg/errors"
 	"github.com/valyala/fasthttp"
+	"github.com/valyala/fasthttp/fasthttpadaptor"
 	"github.com/valyala/fasthttp/pprofhandler"
 	"github.com/valyala/fastjson"
 	"golang.org/x/crypto/acme/autocert"
@@ -210,9 +211,13 @@ func (g *Gateway) StartHTTPS(httpPort int, c *skademlia.Client, l *wavelet.Ledge
 	// Let autocert handle Let's Encrypt auth callbacks over HTTP. All other URLs will pass into the fallback handler.
 	certHandler := certManager.HTTPHandler(http.HandlerFunc(fallback))
 
+	httpServer := &fasthttp.Server{
+		Handler: fasthttpadaptor.NewFastHTTPHandler(certHandler),
+	}
+
 	// Start HTTP server to handle Let's Encrypt auth callbacks over HTTP and to redirect HTTP into HTTPS.
 	go func() {
-		if err := http.ListenAndServe(":"+strconv.Itoa(httpPort), certHandler); err != nil {
+		if err := httpServer.ListenAndServe(":" + strconv.Itoa(httpPort)); err != nil {
 			logger.Fatal().Err(err).Msg("Failed to start HTTP server.")
 		}
 	}()

--- a/api/mod.go
+++ b/api/mod.go
@@ -32,7 +32,6 @@ import (
 	"github.com/perlin-network/wavelet/sys"
 	"github.com/pkg/errors"
 	"github.com/valyala/fasthttp"
-	"github.com/valyala/fasthttp/fasthttpadaptor"
 	"github.com/valyala/fasthttp/pprofhandler"
 	"github.com/valyala/fastjson"
 	"golang.org/x/crypto/acme/autocert"
@@ -211,13 +210,9 @@ func (g *Gateway) StartHTTPS(httpPort int, c *skademlia.Client, l *wavelet.Ledge
 	// Let autocert handle Let's Encrypt auth callbacks over HTTP. All other URLs will pass into the fallback handler.
 	certHandler := certManager.HTTPHandler(http.HandlerFunc(fallback))
 
-	httpServer := &fasthttp.Server{
-		Handler: fasthttpadaptor.NewFastHTTPHandler(certHandler),
-	}
-
 	// Start HTTP server to handle Let's Encrypt auth callbacks over HTTP and to redirect HTTP into HTTPS.
 	go func() {
-		if err := httpServer.ListenAndServe(":" + strconv.Itoa(httpPort)); err != nil {
+		if err := http.ListenAndServe(":"+strconv.Itoa(httpPort), certHandler); err != nil {
 			logger.Fatal().Err(err).Msg("Failed to start HTTP server.")
 		}
 	}()

--- a/cmd/wavelet/main.go
+++ b/cmd/wavelet/main.go
@@ -119,7 +119,7 @@ func Run(args []string, stdin io.ReadCloser, stdout io.Writer, withoutGC bool) {
 		}),
 		altsrc.NewStringFlag(cli.StringFlag{
 			Name:   "api.host",
-			Usage:  "Host for the API HTTPS server. Using this flag, api.port must be passed.",
+			Usage:  "Host for the API HTTPS server.",
 			EnvVar: "WAVELET_API_HOST",
 		}),
 		altsrc.NewStringFlag(cli.StringFlag{
@@ -233,10 +233,6 @@ func Run(args []string, stdin io.ReadCloser, stdout io.Writer, withoutGC bool) {
 
 		if apiHost := c.String("api.host"); len(apiHost) > 0 {
 			config.APIHost = &apiHost
-
-			if config.APIPort == 0 {
-				return errors.New("api.port cannot be zero if api.host is passed")
-			}
 		}
 
 		// set the the sys variables
@@ -383,11 +379,7 @@ func start(cfg *Config, stdin io.ReadCloser, stdout io.Writer) {
 	}
 
 	if cfg.APIHost != nil {
-		if cfg.APIPort == 0 {
-			logger.Fatal().Msg("port is zero")
-		}
-
-		go api.New().StartHTTPS(int(cfg.APIPort), client, ledger, keys, *cfg.APIHost, "certs")
+		go api.New().StartHTTPS(client, ledger, keys, *cfg.APIHost, "certs")
 	} else {
 		if cfg.APIPort > 0 {
 			go api.New().StartHTTP(int(cfg.APIPort), client, ledger, keys)

--- a/cmd/wavelet/main.go
+++ b/cmd/wavelet/main.go
@@ -379,7 +379,7 @@ func start(cfg *Config, stdin io.ReadCloser, stdout io.Writer) {
 	}
 
 	if cfg.APIHost != nil {
-		go api.New().StartHTTPS(client, ledger, keys, *cfg.APIHost, "certs")
+		go api.New().StartHTTPS(int(cfg.APIPort), client, ledger, keys, *cfg.APIHost, "certs")
 	} else {
 		if cfg.APIPort > 0 {
 			go api.New().StartHTTP(int(cfg.APIPort), client, ledger, keys)

--- a/cmd/wavelet/main.go
+++ b/cmd/wavelet/main.go
@@ -216,7 +216,6 @@ func Run(args []string, stdin io.ReadCloser, stdout io.Writer, withoutGC bool) {
 	}
 
 	app.Action = func(c *cli.Context) error {
-		c.String("config")
 		config := &Config{
 			Host:        c.String("host"),
 			Port:        c.Uint("port"),

--- a/cmd/wavelet/main.go
+++ b/cmd/wavelet/main.go
@@ -105,13 +105,13 @@ func Run(args []string, stdin io.ReadCloser, stdout io.Writer, withoutGC bool) {
 			Usage:  "Listen for peers on host address.",
 			EnvVar: "WAVELET_NODE_HOST",
 		}),
-		altsrc.NewIntFlag(cli.IntFlag{
+		altsrc.NewUintFlag(cli.UintFlag{
 			Name:   "port",
 			Value:  3000,
 			Usage:  "Listen for peers on port.",
 			EnvVar: "WAVELET_NODE_PORT",
 		}),
-		altsrc.NewIntFlag(cli.IntFlag{
+		altsrc.NewUintFlag(cli.UintFlag{
 			Name:   "api.port",
 			Value:  0,
 			Usage:  "Host a local HTTP API at port.",

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0
 	github.com/valyala/fasthttp v1.3.0
 	github.com/valyala/fastjson v1.4.1
-	golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f
+	golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472
 	golang.org/x/net v0.0.0-20190522155817-f3200d17e092
 	golang.org/x/sys v0.0.0-20190522044717-8097e1b27ff5 // indirect
 	golang.org/x/text v0.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxt
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f h1:R423Cnkcp5JABoeemiGEPlt9tHXFfw5kvc0yqlxRPWo=
 golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472 h1:Gv7RPwsi3eZ2Fgewe3CBsuOebPwO27PoXzRpJPsvSSM=
+golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180911220305-26e67e76b6c3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
Implement HTTPS API server using Let's Encrypt.

Add new flag `-api.host` which is the domain. 

To enable HTTPS, pass the flag `-api.host`, and also `api.port`.

The `api.port` is used to start a HTTP server to handle Let's Encrypt auth callbacks, and redirect all  HTTP traffic into HTTPS.