### PR TITLE
Make the computation of a rounds difficulty factor more robust to attacks by adversaries, and reduce round binary size.

### DIFF
--- a/api/msg.go
+++ b/api/msg.go
@@ -219,7 +219,7 @@ func (s *ledgerStatusResponse) marshalJSON(arena *fastjson.Arena) ([]byte, error
 	r.Set("merkle_root", arena.NewString(hex.EncodeToString(round.Merkle[:])))
 	r.Set("start_id", arena.NewString(hex.EncodeToString(round.Start.ID[:])))
 	r.Set("end_id", arena.NewString(hex.EncodeToString(round.End.ID[:])))
-	r.Set("applied", arena.NewNumberString(strconv.FormatUint(round.Applied, 10)))
+	r.Set("transactions", arena.NewNumberString(strconv.FormatUint(uint64(round.Transactions), 10)))
 	r.Set("depth", arena.NewNumberString(strconv.FormatUint(round.End.Depth-round.Start.Depth, 10)))
 	r.Set("difficulty", arena.NewNumberString(strconv.FormatUint(uint64(round.ExpectedDifficulty(sys.MinDifficulty, sys.DifficultyScaleFactor)), 10)))
 

--- a/contract_test.go
+++ b/contract_test.go
@@ -59,7 +59,7 @@ func BenchmarkContractInGraph(b *testing.B) {
 			err = accountState.Commit(results.snapshot)
 			assert.NoError(b, err)
 			state = results.snapshot
-			round = NewRound(viewID+1, state.Checksum(), uint64(results.appliedCount), round.End, tx)
+			round = NewRound(viewID+1, state.Checksum(), uint32(results.appliedCount+results.rejectedCount), round.End, tx)
 			viewID += 1
 			criticalCount += 1
 		}

--- a/ledger.go
+++ b/ledger.go
@@ -661,7 +661,7 @@ FINALIZE_ROUNDS:
 				continue
 			}
 
-			candidate := NewRound(current.Index+1, results.snapshot.Checksum(), uint64(results.appliedCount), current.End, *eligible)
+			candidate := NewRound(current.Index+1, results.snapshot.Checksum(), uint32(results.appliedCount+results.rejectedCount), current.End, *eligible)
 			l.finalizer.Prefer(&candidate)
 
 			continue FINALIZE_ROUNDS
@@ -761,8 +761,8 @@ FINALIZE_ROUNDS:
 							return
 						}
 
-						if uint64(results.appliedCount) != round.Applied {
-							fmt.Printf("applied %d but expected %d, rejected = %d, ignored = %d\n", results.appliedCount, round.Applied, results.rejectedCount, results.ignoredCount)
+						if uint32(results.appliedCount+results.rejectedCount) != round.Transactions {
+							fmt.Printf("applied %d but expected %d, rejected = %d, ignored = %d\n", results.appliedCount, round.Transactions, results.rejectedCount, results.ignoredCount)
 							return
 						}
 
@@ -828,8 +828,8 @@ FINALIZE_ROUNDS:
 			continue
 		}
 
-		if uint64(results.appliedCount) != preferred.Applied {
-			fmt.Printf("Expected to have applied %d transactions finalizing a round, but only applied %d transactions instead.\n", preferred.Applied, results.appliedCount)
+		if uint32(results.appliedCount+results.rejectedCount) != preferred.Transactions {
+			fmt.Printf("Expected to have applied %d transactions finalizing a round, but only applied %d transactions instead.\n", preferred.Transactions, results.appliedCount)
 			continue
 		}
 

--- a/ledger_test.go
+++ b/ledger_test.go
@@ -1,11 +1,11 @@
 package wavelet
 
 import (
+	"github.com/perlin-network/wavelet/conf"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/perlin-network/wavelet/sys"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -311,7 +311,7 @@ func TestLedger_Sync(t *testing.T) {
 	testnet.WaitForSync(t)
 
 	// Advance the network by a few rounds larger than sys.SyncIfRoundsDifferBy
-	for i := 0; i < int(sys.SyncIfRoundsDifferBy)+5; i++ {
+	for i := 0; i < int(conf.GetSyncIfRoundsDifferBy())+5; i++ {
 		<-alice.WaitForSync()
 		_, err := alice.PlaceStake(10)
 		if err != nil {

--- a/round.go
+++ b/round.go
@@ -39,19 +39,19 @@ type Round struct {
 	Index  uint64
 	Merkle MerkleNodeID
 
-	Applied uint64
+	Transactions uint32
 
 	Start Transaction
 	End   Transaction
 }
 
-func NewRound(index uint64, merkle MerkleNodeID, applied uint64, start, end Transaction) Round {
+func NewRound(index uint64, merkle MerkleNodeID, transactions uint32, start, end Transaction) Round {
 	r := Round{
-		Index:   index,
-		Merkle:  merkle,
-		Applied: applied,
-		Start:   start,
-		End:     end,
+		Index:        index,
+		Merkle:       merkle,
+		Transactions: transactions,
+		Start:        start,
+		End:          end,
 	}
 
 	r.ID = blake2b.Sum256(r.Marshal())
@@ -77,7 +77,7 @@ func (r Round) Marshal() []byte {
 
 	w.Write(r.Merkle[:])
 
-	binary.BigEndian.PutUint64(buf[:], r.Applied)
+	binary.BigEndian.PutUint32(buf[:], r.Transactions)
 	w.Write(buf[:8])
 
 	w.Write(r.Start.Marshal())
@@ -87,11 +87,11 @@ func (r Round) Marshal() []byte {
 }
 
 func (r Round) ExpectedDifficulty(min byte, scale float64) byte {
-	if r.End.Depth == 0 || r.Applied == 0 {
+	if r.End.Depth == 0 || r.Transactions == 0 {
 		return min
 	}
 
-	maxs := r.Applied
+	maxs := uint64(r.Transactions)
 	mins := r.End.Depth - r.Start.Depth
 
 	if mins > maxs {
@@ -121,7 +121,7 @@ func UnmarshalRound(r io.Reader) (round Round, err error) {
 		return
 	}
 
-	round.Applied = binary.BigEndian.Uint64(buf[:8])
+	round.Transactions = binary.BigEndian.Uint32(buf[:8])
 
 	if round.Start, err = UnmarshalTransaction(r); err != nil {
 		err = errors.Wrap(err, "failed to decode round start transaction")

--- a/tx_applier_test.go
+++ b/tx_applier_test.go
@@ -176,7 +176,7 @@ func TestApplyTransaction_Collapse(t *testing.T) {
 			err = accountState.Commit(results.snapshot)
 			assert.NoError(t, err)
 			state = results.snapshot
-			round = NewRound(viewID+1, state.Checksum(), uint64(results.appliedCount), round.End, tx)
+			round = NewRound(viewID+1, state.Checksum(), uint32(results.appliedCount+results.rejectedCount), round.End, tx)
 			viewID += 1
 
 			for id, account := range accounts {


### PR DESCRIPTION
api, ledger, round, tests: compute the difficulty factor based on the total number of applied/rejected transactions in a round
round: reduce transaction count to uint32 to prevent sending out 4 extra bytes per round