### PR TITLE
Fix a panic (send on closed channel) in SyncToLatestRound

### DIFF
--- a/ledger.go
+++ b/ledger.go
@@ -1002,7 +1002,7 @@ func (l *Ledger) SyncToLatestRound() {
 
 		restart := func() { // Respawn all previously stopped workers.
 			snowballK := conf.GetSnowballK()
-			syncVotes := make(chan vote, snowballK)
+			syncVotes = make(chan vote, snowballK)
 			go CollectVotes(l.accounts, l.syncer, syncVotes, voteWG, snowballK)
 
 			l.sync = make(chan struct{})


### PR DESCRIPTION
The panic is caused by a single character mistake in ledger.SyncToLatestRound()
The mistake cause a new variable to be created instead of updating the existing variable.