### PR TITLE
Some micro optimizations in db.go and node.go

### DIFF
--- a/avl/node.go
+++ b/avl/node.go
@@ -329,11 +329,13 @@ func (n *node) rehash() {
 
 func (n *node) rehashNoWrite() [MerkleHashSize]byte {
 	buf := bytebufferpool.Get()
-	defer bytebufferpool.Put(buf)
 	n.serialize(buf)
-	data := buf.Bytes()
 
-	return highwayhash.Sum128(data, hashKey)
+	hash := highwayhash.Sum128(buf.Bytes(), hashKey)
+
+	bytebufferpool.Put(buf)
+
+	return hash
 }
 
 func (n *node) clone() *node {

--- a/avl/node_test.go
+++ b/avl/node_test.go
@@ -1,0 +1,32 @@
+package avl
+
+import (
+	"crypto/rand"
+	"github.com/perlin-network/wavelet/store"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func BenchmarkRehashNoWrite(b *testing.B) {
+	kv, cleanup := store.NewTestKV(b, "inmem", "")
+	defer cleanup()
+
+	tree := New(kv)
+
+	var key [32] byte
+	_, err := rand.Read(key[:])
+	assert.NoError(b, err)
+
+	var val [64] byte
+	_, err = rand.Read(val[:])
+	assert.NoError(b, err)
+
+	node := newLeafNode(tree, key[:], val[:])
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for n := 0; n < b.N; n++ {
+		node.rehashNoWrite()
+	}
+}

--- a/db_test.go
+++ b/db_test.go
@@ -20,6 +20,7 @@
 package wavelet
 
 import (
+	"encoding/binary"
 	"github.com/perlin-network/wavelet/avl"
 	"github.com/perlin-network/wavelet/store"
 	"github.com/stretchr/testify/assert"
@@ -55,4 +56,172 @@ func TestRewardWithdrawals(t *testing.T) {
 
 	assert.Equal(t, 7, len(rws))
 	assert.True(t, sort.SliceIsSorted(rws, func(i, j int) bool { return rws[i].round < rws[j].round }))
+}
+
+func TestReadUnderAccounts(t *testing.T) {
+	stateStore := store.NewInmem()
+	state := avl.New(stateStore)
+
+	var id AccountID
+	_, err := rand.Read(id[:])
+	assert.NoError(t, err)
+	WriteAccountBalance(state, id, 1000)
+
+	var expectedBal [8]byte
+	binary.LittleEndian.PutUint64(expectedBal[:], uint64(1000))
+
+	bal, exist := readUnderAccounts(state, id, keyAccountBalance[:])
+	assert.True(t, exist)
+	assert.Equal(t, expectedBal[:], bal)
+}
+
+func TestWriteUnderAccounts(t *testing.T) {
+	stateStore := store.NewInmem()
+	state := avl.New(stateStore)
+
+	var id AccountID
+	_, err := rand.Read(id[:])
+	assert.NoError(t, err)
+
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(1000))
+
+	writeUnderAccounts(state, id, keyAccountBalance[:], buf[:])
+
+	bal, exist := ReadAccountBalance(state, id)
+	assert.True(t, exist)
+	assert.Equal(t, uint64(1000), bal)
+}
+
+func TestReadAccountContractPage(t *testing.T) {
+	stateStore := store.NewInmem()
+	state := avl.New(stateStore)
+
+	var id TransactionID
+	_, err := rand.Read(id[:])
+	assert.NoError(t, err)
+
+	var page [512]byte
+	_, err = rand.Read(page[:])
+	assert.NoError(t, err)
+
+	WriteAccountContractPage(state, id, 0, page[:])
+
+	actualPage, exist := ReadAccountContractPage(state, id, 0)
+	assert.True(t, exist)
+	assert.Equal(t, page[:], actualPage)
+}
+
+func TestWriteAccountContractPage(t *testing.T) {
+	stateStore := store.NewInmem()
+	state := avl.New(stateStore)
+
+	var id TransactionID
+	_, err := rand.Read(id[:])
+	assert.NoError(t, err)
+
+	var page [512]byte
+	_, err = rand.Read(page[:])
+	assert.NoError(t, err)
+
+	WriteAccountContractPage(state, id, 0, page[:])
+
+	_, exist := ReadAccountContractPage(state, id, 0)
+	assert.True(t, exist)
+}
+
+func BenchmarkReadUnderAccounts(b *testing.B) {
+	stateStore := store.NewInmem()
+	state := avl.New(stateStore)
+
+	var id AccountID
+	_, err := rand.Read(id[:])
+	assert.NoError(b, err)
+
+	WriteAccountBalance(state, id, 1000)
+
+	var expectedBal [8]byte
+	binary.LittleEndian.PutUint64(expectedBal[:], uint64(1000))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	var bal []byte
+	var exist bool
+	for n := 0; n < b.N; n++ {
+		bal, exist = readUnderAccounts(state, id, keyAccountBalance[:])
+	}
+
+	assert.True(b, exist)
+	assert.Equal(b, expectedBal[:], bal)
+}
+
+func BenchmarkWriteUnderAccounts(b *testing.B) {
+	stateStore := store.NewInmem()
+	state := avl.New(stateStore)
+
+	var id AccountID
+	_, err := rand.Read(id[:])
+	assert.NoError(b, err)
+
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(1000))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		writeUnderAccounts(state, id, keyAccountBalance[:], buf[:])
+	}
+
+	bal, exist := ReadAccountBalance(state, id)
+	assert.True(b, exist)
+	assert.Equal(b, uint64(1000), bal)
+}
+
+func BenchmarkReadAccountContractPage(b *testing.B) {
+	stateStore := store.NewInmem()
+	state := avl.New(stateStore)
+
+	var id TransactionID
+	_, err := rand.Read(id[:])
+	assert.NoError(b, err)
+
+	var expectedPage [512]byte
+	_, err = rand.Read(expectedPage[:])
+	assert.NoError(b, err)
+
+	WriteAccountContractPage(state, id, 0, expectedPage[:])
+
+	var page []byte
+	var exist bool
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		page, exist = ReadAccountContractPage(state, id, 0)
+	}
+
+	assert.True(b, exist)
+	assert.Equal(b, expectedPage[:], page)
+}
+
+func BenchmarkWriteAccountContractPage(b *testing.B) {
+	stateStore := store.NewInmem()
+	state := avl.New(stateStore)
+
+	var id TransactionID
+	_, err := rand.Read(id[:])
+	assert.NoError(b, err)
+
+	var page [512]byte
+	_, err = rand.Read(page[:])
+	assert.NoError(b, err)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		WriteAccountContractPage(state, id, 0, page[:])
+	}
+
+	_, exist := ReadAccountContractPage(state, id, 0)
+	assert.True(b, exist)
 }


### PR DESCRIPTION
From the collapseTransactions benchmarks, I notice some slice allocations that can be reduced and the cost of defer() in node.go.

By improving the slice allocations and remove the use defer() in node.rehashNoWrite(), I saw there are some performance improvements, albeit minor in some cases.

Following are the statistics of the benchmarks. 
The benchmarks are ran 100 times.

<br />

Remove defer() in node.rehashNoWrite()
```
name             old time/op    new time/op    delta
RehashNoWrite-8     151ns ± 6%     120ns ± 5%  -20.39%  (p=0.000 n=96+95)
```

<br />

Preallocate the slices

<br />

```
name                 old time/op    new time/op    delta
ReadUnderAccounts-8    77.4ns ± 7%    42.4ns ± 8%  -45.24%  (p=0.000 n=86+98)

name                 old alloc/op   new alloc/op   delta
ReadUnderAccounts-8     96.0B ± 0%     48.0B ± 0%  -50.00%  (p=0.000 n=100+100)

name                 old allocs/op  new allocs/op  delta
ReadUnderAccounts-8      2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.000 n=100+100)
```

<br />

```
name                  old time/op    new time/op    delta
WriteUnderAccounts-8     327ns ± 0%     320ns ±26%   -2.12%  (p=0.000 n=64+97)

name                  old alloc/op   new alloc/op   delta
WriteUnderAccounts-8      240B ± 0%      192B ± 0%  -20.00%  (p=0.000 n=100+100)

name                  old allocs/op  new allocs/op  delta
WriteUnderAccounts-8      3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.000 n=100+100)
```

<br />

```
name                       old time/op    new time/op    delta
ReadAccountContractPage-8     217ns ±16%     198ns ± 8%   -8.96%  (p=0.000 n=88+86)

name                       old alloc/op   new alloc/op   delta
ReadAccountContractPage-8      624B ± 0%      608B ± 0%   -2.56%  (p=0.000 n=100+100)

name                       old allocs/op  new allocs/op  delta
ReadAccountContractPage-8      4.00 ± 0%      3.00 ± 0%  -25.00%  (p=0.000 n=100+100)
```

<br />

```
name                        old time/op    new time/op    delta
WriteAccountContractPage-8     731ns ± 3%     699ns ± 2%   -4.44%  (p=0.000 n=86+97)

name                        old alloc/op   new alloc/op   delta
WriteAccountContractPage-8      848B ± 0%      832B ± 0%   -1.89%  (p=0.000 n=100+100)

name                        old allocs/op  new allocs/op  delta
WriteAccountContractPage-8      4.00 ± 0%      3.00 ± 0%  -25.00%  (p=0.000 n=100+100)
```

