### PR TITLE
Allow setting log level via cli parameters

### DIFF
--- a/cmd/wavelet/main_test.go
+++ b/cmd/wavelet/main_test.go
@@ -56,6 +56,16 @@ func TestMain_WithLogLevel(t *testing.T) {
 	}
 }
 
+func TestMain_WithInvalidLogLevel(t *testing.T) {
+	// Invalid loglevel will cause the ledger to use the default log level,
+	// which is debug
+	w := NewTestWavelet(t, &TestWaveletConfig{LogLevel: "foobar"})
+	defer w.Cleanup()
+
+	w.Stdin <- "status"
+	w.Stdout.Search(t, "Here is the current status of your node")
+}
+
 func TestMain_WithWalletString(t *testing.T) {
 	wallet := "b27b880e6e44e3b127186a08bc5698316e8dd99157cec56211560b62141f0851c72096021609681eb8cab244752945b2008e1b51d8bc2208b2b562f35485d5cc"
 	w := NewTestWavelet(t, &TestWaveletConfig{Wallet: wallet})

--- a/cmd/wavelet/main_test.go
+++ b/cmd/wavelet/main_test.go
@@ -25,6 +25,16 @@ import (
 var wallet1 = "87a6813c3b4cf534b6ae82db9b1409fa7dbd5c13dba5858970b56084c4a930eb400056ee68a7cc2695222df05ea76875bc27ec6e61e8e62317c336157019c405"
 var wallet2 = "85e7450f7cf0d9cd1d1d7bf4169c2f364eea4ba833a7280e0f931a1d92fd92c2696937c2c8df35dba0169de72990b80761e51dd9e2411fa1fce147f68ade830a"
 
+func TestMain_WithInvalidLogLevel(t *testing.T) {
+	// Invalid loglevel will cause the ledger to use the default log level,
+	// which is debug
+	w := NewTestWavelet(t, &TestWaveletConfig{LogLevel: "foobar"})
+	defer w.Cleanup()
+
+	w.Stdin <- "status"
+	w.Stdout.Search(t, "Here is the current status of your node")
+}
+
 func TestMain(t *testing.T) {
 	w := NewTestWavelet(t, nil)
 	defer w.Cleanup()
@@ -54,16 +64,6 @@ func TestMain_WithLogLevel(t *testing.T) {
 			return
 		}
 	}
-}
-
-func TestMain_WithInvalidLogLevel(t *testing.T) {
-	// Invalid loglevel will cause the ledger to use the default log level,
-	// which is debug
-	w := NewTestWavelet(t, &TestWaveletConfig{LogLevel: "foobar"})
-	defer w.Cleanup()
-
-	w.Stdin <- "status"
-	w.Stdout.Search(t, "Here is the current status of your node")
 }
 
 func TestMain_WithWalletString(t *testing.T) {

--- a/collapse.go
+++ b/collapse.go
@@ -22,7 +22,7 @@ package wavelet
 import (
 	"encoding/binary"
 	"encoding/hex"
-	"fmt"
+
 	"github.com/perlin-network/wavelet/avl"
 	"github.com/perlin-network/wavelet/conf"
 	"github.com/perlin-network/wavelet/log"
@@ -250,7 +250,8 @@ func collapseTransactions(g *Graph, accounts *Accounts, round uint64, current *R
 			res.rejectedErrors = append(res.rejectedErrors, err)
 			res.rejectedCount += popped.LogicalUnits()
 
-			fmt.Println("error applying transaction", err)
+			logger := log.Node()
+			logger.Error().Err(err).Msg("error applying transaction")
 
 			continue
 		}

--- a/ledger.go
+++ b/ledger.go
@@ -403,6 +403,8 @@ func (l *Ledger) SyncTransactions() {
 	l.consensus.Add(1)
 	defer l.consensus.Done()
 
+	logger := log.Consensus("transaction-sync")
+
 	pullingPeriod := 1 * time.Second
 	t := time.NewTimer(pullingPeriod)
 
@@ -466,7 +468,7 @@ func (l *Ledger) SyncTransactions() {
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		batch, err := client.DownloadTx(ctx, req)
 		if err != nil {
-			fmt.Println("failed to download missing transactions:", err)
+			logger.Error().Err(err).Msg("failed to download missing transactions")
 			cancel()
 			continue
 		}
@@ -476,12 +478,18 @@ func (l *Ledger) SyncTransactions() {
 		for _, buf := range batch.Transactions {
 			tx, err := UnmarshalTransaction(bytes.NewReader(buf))
 			if err != nil {
-				fmt.Printf("error unmarshaling downloaded tx [%v]: %+v", err, tx)
+				logger.Error().
+					Err(err).
+					Hex("tx_id", tx.ID[:]).
+					Msg("failed to download missing transactions")
 				continue
 			}
 
 			if err := l.AddTransaction(tx); err != nil && errors.Cause(err) != ErrMissingParents {
-				fmt.Printf("error adding synced tx to graph [%v]: %+v\n", err, tx)
+				logger.Error().
+					Err(err).
+					Hex("tx_id", tx.ID[:]).
+					Msg("failed to download missing transactions")
 				continue
 			}
 
@@ -490,7 +498,6 @@ func (l *Ledger) SyncTransactions() {
 		}
 
 		if txCount > 0 {
-			logger := log.Consensus("transaction-sync")
 			logger.Debug().
 				Int("synced_tx", txCount).
 				Int("logical_tx", logicalCount).
@@ -568,10 +575,12 @@ func (l *Ledger) PullMissingTransactions() {
 		conn := peers[0]
 		client := NewWaveletClient(conn)
 
+		logger := log.Consensus("pull-missing-transactions")
+
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		batch, err := client.DownloadMissingTx(ctx, req)
 		if err != nil {
-			fmt.Println("failed to download missing transactions:", err)
+			logger.Error().Err(err).Msg("failed to download missing transactions")
 			cancel()
 			continue
 		}
@@ -582,12 +591,18 @@ func (l *Ledger) PullMissingTransactions() {
 		for _, buf := range batch.Transactions {
 			tx, err := UnmarshalTransaction(bytes.NewReader(buf))
 			if err != nil {
-				fmt.Printf("error unmarshaling downloaded tx [%v]: %+v\n", err, tx)
+				logger.Error().
+					Err(err).
+					Hex("tx_id", tx.ID[:]).
+					Msg("error unmarshaling downloaded tx")
 				continue
 			}
 
 			if err := l.AddTransaction(tx); err != nil && errors.Cause(err) != ErrMissingParents {
-				fmt.Printf("error adding downloaded tx to graph [%v]: %+v\n", err, tx)
+				logger.Error().
+					Err(err).
+					Hex("tx_id", tx.ID[:]).
+					Msg("error adding downloaded tx to graph")
 				continue
 			}
 
@@ -659,7 +674,10 @@ FINALIZE_ROUNDS:
 
 			results, err := l.collapseTransactions(current.Index+1, current.End, *eligible, false)
 			if err != nil {
-				fmt.Println("error collapsing transactions during finalization", err)
+				logger := log.Node()
+				logger.Error().
+					Err(err).
+					Msg("error collapsing transactions during finalization")
 				continue
 			}
 
@@ -701,8 +719,12 @@ FINALIZE_ROUNDS:
 
 						res, err := client.Query(ctx, req, grpc.Peer(p))
 						if err != nil {
+							logger := log.Node()
+							logger.Error().
+								Err(err).
+								Msg("error while querying peer")
+
 							cancel()
-							fmt.Println("error while querying peer: ", err)
 							return
 						}
 
@@ -758,18 +780,34 @@ FINALIZE_ROUNDS:
 						results, err := l.collapseTransactions(round.Index, round.Start, round.End, false)
 						if err != nil {
 							if !strings.Contains(err.Error(), "missing ancestor") {
-								fmt.Println("error collapsing transactions:", err)
+								logger := log.Node()
+								logger.Error().
+									Err(err).
+									Msg("error collapsing transactions")
 							}
 							return
 						}
 
 						if uint32(results.appliedCount+results.rejectedCount) != round.Transactions {
-							fmt.Printf("applied %d but expected %d, rejected = %d, ignored = %d\n", results.appliedCount, round.Transactions, results.rejectedCount, results.ignoredCount)
+							logger := log.Node()
+							logger.Error().
+								Err(err).
+								Uint32("expected", round.Transactions).
+								Int("actual", results.appliedCount).
+								Int("rejected", results.rejectedCount).
+								Int("ignored", results.ignoredCount).
+								Msg("Number of applied transactions does not match")
 							return
 						}
 
 						if results.snapshot.Checksum() != round.Merkle {
-							fmt.Printf("got merkle %x but expected %x\n", results.snapshot.Checksum(), round.Merkle)
+							actualMerkle := results.snapshot.Checksum()
+							logger := log.Node()
+							logger.Error().
+								Err(err).
+								Hex("expected", round.Merkle[:]).
+								Hex("actual", actualMerkle[:]).
+								Msg("Unexpected round merkle root")
 							return
 						}
 
@@ -825,24 +863,41 @@ FINALIZE_ROUNDS:
 		results, err := l.collapseTransactions(preferred.Index, preferred.Start, preferred.End, true)
 		if err != nil {
 			if !strings.Contains(err.Error(), "missing ancestor") {
-				fmt.Println("error collapsing transactions during finalization:", err)
+				logger := log.Node()
+				logger.Error().
+					Err(err).
+					Msg("error collapsing transactions during finalization")
 			}
 			continue
 		}
 
 		if uint32(results.appliedCount+results.rejectedCount) != preferred.Transactions {
-			fmt.Printf("Expected to have applied %d transactions finalizing a round, but only applied %d transactions instead.\n", preferred.Transactions, results.appliedCount)
+			logger := log.Node()
+			logger.Error().
+				Err(err).
+				Uint32("expected", preferred.Transactions).
+				Int("actual", results.appliedCount).
+				Msg("Number of applied transactions does not match")
 			continue
 		}
 
 		if results.snapshot.Checksum() != preferred.Merkle {
-			fmt.Printf("Expected preferred round's merkle root to be %x, but got %x.\n", preferred.Merkle, results.snapshot.Checksum())
+			logger := log.Node()
+			actualMerkle := results.snapshot.Checksum()
+			logger.Error().
+				Err(err).
+				Hex("expected", preferred.Merkle[:]).
+				Hex("actual", actualMerkle[:]).
+				Msg("Unexpected round merkle root")
 			continue
 		}
 
 		pruned, err := l.rounds.Save(preferred)
 		if err != nil {
-			fmt.Printf("Failed to save preferred round to our database: %v\n", err)
+			logger := log.Node()
+			logger.Error().
+				Err(err).
+				Msg("Failed to save preferred round to our database")
 		}
 
 		if pruned != nil {
@@ -859,7 +914,10 @@ FINALIZE_ROUNDS:
 		l.graph.UpdateRootDepth(preferred.End.Depth)
 
 		if err = l.accounts.Commit(results.snapshot); err != nil {
-			fmt.Printf("Failed to commit collaped state to our database: %v\n", err)
+			logger := log.Node()
+			logger.Error().
+				Err(err).
+				Msg("Failed to commit collaped state to our database")
 		}
 
 		l.metrics.acceptedTX.Mark(int64(results.appliedCount))
@@ -902,6 +960,8 @@ func (l *Ledger) SyncToLatestRound() {
 	snowballK := conf.GetSnowballK()
 	syncVotes := make(chan vote, snowballK)
 
+	logger := log.Sync("sync")
+
 	go CollectVotes(l.accounts, l.syncer, syncVotes, voteWG, snowballK)
 
 	syncTimeoutMultiplier := 0
@@ -935,7 +995,10 @@ func (l *Ledger) SyncToLatestRound() {
 						grpc.Peer(p),
 					)
 					if err != nil {
-						fmt.Println("error while checking out of sync", err)
+						logger.Error().
+							Err(err).
+							Msg("error while checking out of sync")
+
 						cancel()
 						wg.Done()
 						return
@@ -1013,7 +1076,6 @@ func (l *Ledger) SyncToLatestRound() {
 
 		shutdown() // Shutdown all consensus-related workers.
 
-		logger := log.Sync("syncing")
 		logger.Info().
 			Uint64("current_round", current.Index).
 			Msg("Noticed that we are out of sync; downloading latest state Snapshot from our peer(s).")
@@ -1312,7 +1374,9 @@ func (l *Ledger) SyncToLatestRound() {
 
 		pruned, err := l.rounds.Save(latest)
 		if err != nil {
-			fmt.Printf("Failed to save finalized round to our database: %v\n", err)
+			logger.Error().
+				Err(err).
+				Msg("Failed to save finalized round to our database")
 			goto SYNC
 		}
 

--- a/ledger.go
+++ b/ledger.go
@@ -25,12 +25,13 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"github.com/perlin-network/wavelet/conf"
-	"github.com/perlin-network/wavelet/lru"
 	"math/rand"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/perlin-network/wavelet/conf"
+	"github.com/perlin-network/wavelet/lru"
 
 	"github.com/perlin-network/noise"
 	"github.com/perlin-network/noise/skademlia"

--- a/log/mod.go
+++ b/log/mod.go
@@ -20,8 +20,9 @@
 package log
 
 import (
-	"github.com/rs/zerolog"
 	"io"
+
+	"github.com/rs/zerolog"
 )
 
 var (
@@ -73,6 +74,20 @@ func setupChildLoggers() {
 	stake = logger.With().Str(KeyModule, ModuleStake).Logger()
 	tx = logger.With().Str(KeyModule, ModuleTX).Logger()
 	metrics = logger.With().Str(KeyModule, ModuleMetrics).Logger()
+}
+
+func SetLevel(level string) {
+	if l, err := zerolog.ParseLevel(level); err == nil {
+		node = node.Level(l)
+		network = network.Level(l)
+		accounts = accounts.Level(l)
+		consensus = consensus.Level(l)
+		contract = contract.Level(l)
+		syncer = syncer.Level(l)
+		stake = stake.Level(l)
+		tx = tx.Level(l)
+		metrics = metrics.Level(l)
+	}
 }
 
 func SetWriter(key string, writer io.Writer) {

--- a/protocol.go
+++ b/protocol.go
@@ -22,7 +22,7 @@ package wavelet
 import (
 	"bytes"
 	"context"
-	"fmt"
+
 	"github.com/perlin-network/wavelet/conf"
 	"github.com/perlin-network/wavelet/log"
 	"github.com/pkg/errors"
@@ -51,7 +51,11 @@ func (p *Protocol) Gossip(stream Wavelet_GossipServer) error {
 			}
 
 			if err := p.ledger.AddTransaction(tx); err != nil && errors.Cause(err) != ErrMissingParents {
-				fmt.Printf("error adding incoming tx to graph [%v]: %+v\n", err, tx)
+				logger := log.TX("gossip")
+				logger.Error().
+					Err(err).
+					Hex("tx_id", tx.ID[:]).
+					Msg("error adding incoming tx to graph")
 			}
 		}
 	}

--- a/snowball.go
+++ b/snowball.go
@@ -20,9 +20,10 @@
 package wavelet
 
 import (
-	"fmt"
-	"github.com/perlin-network/wavelet/conf"
 	"sync"
+
+	"github.com/perlin-network/wavelet/conf"
+	"github.com/perlin-network/wavelet/log"
 )
 
 type SnowballOption func(*Snowball)
@@ -107,7 +108,13 @@ func (s *Snowball) Tick(v Identifiable) {
 
 	if s.lastID != id { // Handle termination case.
 		if s.lastID != "" {
-			fmt.Printf("Snowball (%s) liveness fault: Last ID is %s with count %d, and new ID is %s.\n", s.name, s.lastID, s.count, id)
+			logger := log.Node()
+			logger.Warn().
+				Str("name", s.name).
+				Str("last_id", s.lastID).
+				Int("count", s.count).
+				Str("new_id", id).
+				Msg("Snowball liveness fault")
 		}
 
 		s.lastID = id


### PR DESCRIPTION
Refer to #212. This PR adds `-loglevel` cli param, which overrides the log level for all loggers in the `log` package.