### PR TITLE
Remove hardcoded timeout values

### DIFF
--- a/cmd/wavelet/actions.go
+++ b/cmd/wavelet/actions.go
@@ -644,6 +644,8 @@ func (cli *CLI) updateParameters(ctx *cli.Context) {
 		conf.WithSnowballBeta(ctx.Int("snowball.beta")),
 		conf.WithQueryTimeout(ctx.Duration("query.timeout")),
 		conf.WithGossipTimeout(ctx.Duration("gossip.timeout")),
+		conf.WithDownloadTxTimeout(ctx.Duration("download.tx.timeout")),
+		conf.WithCheckOutOfSyncTimeout(ctx.Duration("check.out.of.sync.timeout")),
 		conf.WithSyncChunkSize(ctx.Int("sync.chunk.size")),
 		conf.WithSyncIfRoundsDifferBy(ctx.Uint64("sync.if.rounds.differ.by")),
 		conf.WithMaxDownloadDepthDiff(ctx.Uint64("max.download.depth.diff")),

--- a/cmd/wavelet/cli.go
+++ b/cmd/wavelet/cli.go
@@ -22,8 +22,6 @@ package main
 import (
 	"encoding/csv"
 	"fmt"
-	"github.com/perlin-network/wavelet/conf"
-	"github.com/perlin-network/wavelet/store"
 	"io"
 	"strings"
 	"text/tabwriter"
@@ -31,7 +29,9 @@ import (
 	"github.com/benpye/readline"
 	"github.com/perlin-network/noise/skademlia"
 	"github.com/perlin-network/wavelet"
+	"github.com/perlin-network/wavelet/conf"
 	"github.com/perlin-network/wavelet/log"
+	"github.com/perlin-network/wavelet/store"
 	"github.com/rs/zerolog"
 	"github.com/urfave/cli"
 )
@@ -193,6 +193,16 @@ func NewCLI(
 					Name:  "gossip.timeout",
 					Value: conf.GetGossipTimeout(),
 					Usage: "timeout for gossip request",
+				},
+				cli.DurationFlag{
+					Name:  "download.tx.timeout",
+					Value: conf.GetDownloadTxTimeout(),
+					Usage: "timeout for download tx request",
+				},
+				cli.DurationFlag{
+					Name:  "check.out.of.sync.timeout",
+					Value: conf.GetCheckOutOfSyncTimeout(),
+					Usage: "timeout for check out of sync request",
 				},
 				cli.IntFlag{
 					Name:  "sync.chunk.size",

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -13,8 +13,10 @@ type config struct {
 	snowballBeta  int
 
 	// Timeout for outgoing requests
-	queryTimeout  time.Duration
-	gossipTimeout time.Duration
+	queryTimeout          time.Duration
+	gossipTimeout         time.Duration
+	downloadTxTimeout     time.Duration
+	checkOutOfSyncTimeout time.Duration
 
 	// Size of individual chunks sent for a syncing peer.
 	syncChunkSize int
@@ -38,16 +40,18 @@ type config struct {
 
 var (
 	c = config{
-		snowballK:            2,
-		snowballAlpha:        0.8,
-		snowballBeta:         50,
-		queryTimeout:         500 * time.Millisecond,
-		gossipTimeout:        500 * time.Millisecond,
-		syncChunkSize:        16384,
-		syncIfRoundsDifferBy: 2,
-		maxDownloadDepthDiff: 1500,
-		maxDepthDiff:         10,
-		pruningLimit:         30,
+		snowballK:             2,
+		snowballAlpha:         0.8,
+		snowballBeta:          50,
+		queryTimeout:          500 * time.Millisecond,
+		gossipTimeout:         500 * time.Millisecond,
+		downloadTxTimeout:     1 * time.Second,
+		checkOutOfSyncTimeout: 500 * time.Millisecond,
+		syncChunkSize:         16384,
+		syncIfRoundsDifferBy:  2,
+		maxDownloadDepthDiff:  1500,
+		maxDepthDiff:          10,
+		pruningLimit:          30,
 	}
 
 	l = sync.RWMutex{}
@@ -82,6 +86,18 @@ func WithQueryTimeout(qt time.Duration) Option {
 func WithGossipTimeout(gt time.Duration) Option {
 	return func(c *config) {
 		c.gossipTimeout = gt
+	}
+}
+
+func WithDownloadTxTimeout(dt time.Duration) Option {
+	return func(c *config) {
+		c.downloadTxTimeout = dt
+	}
+}
+
+func WithCheckOutOfSyncTimeout(ct time.Duration) Option {
+	return func(c *config) {
+		c.checkOutOfSyncTimeout = ct
 	}
 }
 
@@ -156,6 +172,22 @@ func GetQueryTimeout() time.Duration {
 func GetGossipTimeout() time.Duration {
 	l.RLock()
 	t := c.gossipTimeout
+	l.RUnlock()
+
+	return t
+}
+
+func GetDownloadTxTimeout() time.Duration {
+	l.RLock()
+	t := c.downloadTxTimeout
+	l.RUnlock()
+
+	return t
+}
+
+func GetCheckOutOfSyncTimeout() time.Duration {
+	l.RLock()
+	t := c.checkOutOfSyncTimeout
 	l.RUnlock()
 
 	return t

--- a/ledger.go
+++ b/ledger.go
@@ -30,13 +30,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/perlin-network/wavelet/conf"
-	"github.com/perlin-network/wavelet/lru"
-
 	"github.com/perlin-network/noise"
 	"github.com/perlin-network/noise/skademlia"
 	"github.com/perlin-network/wavelet/avl"
+	"github.com/perlin-network/wavelet/conf"
 	"github.com/perlin-network/wavelet/log"
+	"github.com/perlin-network/wavelet/lru"
 	"github.com/perlin-network/wavelet/store"
 	"github.com/perlin-network/wavelet/sys"
 	"github.com/pkg/errors"
@@ -465,7 +464,7 @@ func (l *Ledger) SyncTransactions() {
 		conn := peers[0]
 		client := NewWaveletClient(conn)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), conf.GetDownloadTxTimeout())
 		batch, err := client.DownloadTx(ctx, req)
 		if err != nil {
 			logger.Error().Err(err).Msg("failed to download missing transactions")
@@ -577,7 +576,7 @@ func (l *Ledger) PullMissingTransactions() {
 
 		logger := log.Consensus("pull-missing-transactions")
 
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), conf.GetDownloadTxTimeout())
 		batch, err := client.DownloadMissingTx(ctx, req)
 		if err != nil {
 			logger.Error().Err(err).Msg("failed to download missing transactions")
@@ -985,7 +984,7 @@ func (l *Ledger) SyncToLatestRound() {
 				client := NewWaveletClient(conn)
 
 				go func() {
-					ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+					ctx, cancel := context.WithTimeout(context.Background(), conf.GetCheckOutOfSyncTimeout())
 
 					p := &peer.Peer{}
 


### PR DESCRIPTION
This PR adds the following config:
- `downloadTxTimeout`: used by `DownloadTx` and `DownloadMissingTx` RPC calls
- `checkOutOfSyncTimeout`: used by `CheckOutOfSync` RPC call