### PR TITLE
Ignore tx error caused by adding transactions with too low depth

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -22,12 +22,12 @@ package wavelet
 import (
 	"bytes"
 	"encoding/hex"
-	"github.com/perlin-network/wavelet/conf"
 	"sort"
 	"sync"
 
 	"github.com/google/btree"
 	"github.com/perlin-network/noise/edwards25519"
+	"github.com/perlin-network/wavelet/conf"
 	"github.com/perlin-network/wavelet/sys"
 	"github.com/pkg/errors"
 )
@@ -134,7 +134,7 @@ func (g *Graph) AddTransaction(tx Transaction) error {
 	}
 
 	if g.rootDepth > conf.GetMaxDepthDiff()+tx.Depth {
-		return errors.Errorf("transactions depth is too low compared to root: root depth is %d, but tx depth is %d", g.rootDepth, tx.Depth)
+		return ErrAlreadyExists
 	}
 
 	if err := g.validateTransaction(tx); err != nil {

--- a/graph.go
+++ b/graph.go
@@ -75,9 +75,10 @@ func (a *sortBySeedTX) Less(b btree.Item) bool {
 }
 
 var (
-	ErrMissingParents     = errors.New("parents for transaction are not in graph")
-	ErrAlreadyExists      = errors.New("transaction already exists in the graph")
-	ErrDepthLimitExceeded = errors.New("transactions parents exceed depth limit")
+	ErrMissingParents           = errors.New("parents for transaction are not in graph")
+	ErrAlreadyExists            = errors.New("transaction already exists in the graph")
+	ErrDepthTooLow              = errors.New("transaction depth is too low")
+	ErrParentDepthLimitExceeded = errors.New("transactions parents exceed depth limit")
 )
 
 type Graph struct {
@@ -134,7 +135,7 @@ func (g *Graph) AddTransaction(tx Transaction) error {
 	}
 
 	if g.rootDepth > conf.GetMaxDepthDiff()+tx.Depth {
-		return ErrAlreadyExists
+		return ErrDepthTooLow
 	}
 
 	if err := g.validateTransaction(tx); err != nil {
@@ -748,7 +749,7 @@ func (g *Graph) validateTransactionParents(tx *Transaction) error {
 		}
 
 		if tx.Depth > conf.GetMaxDepthDiff()+parent.Depth { // Check if the depth of each parents is acceptable.
-			return errors.Wrapf(ErrDepthLimitExceeded, "tx parent has ineligible depth: parents depth is %d, but tx depth is %d", parent.Depth, tx.Depth)
+			return errors.Wrapf(ErrParentDepthLimitExceeded, "tx parent has ineligible depth: parents depth is %d, but tx depth is %d", parent.Depth, tx.Depth)
 		}
 
 		if maxDepth < parent.Depth { // Update max depth witnessed from parents.

--- a/ledger.go
+++ b/ledger.go
@@ -30,13 +30,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/perlin-network/wavelet/conf"
-	"github.com/perlin-network/wavelet/lru"
-
 	"github.com/perlin-network/noise"
 	"github.com/perlin-network/noise/skademlia"
 	"github.com/perlin-network/wavelet/avl"
+	"github.com/perlin-network/wavelet/conf"
 	"github.com/perlin-network/wavelet/log"
+	"github.com/perlin-network/wavelet/lru"
 	"github.com/perlin-network/wavelet/store"
 	"github.com/perlin-network/wavelet/sys"
 	"github.com/pkg/errors"

--- a/ledger.go
+++ b/ledger.go
@@ -230,7 +230,12 @@ func (l *Ledger) Close() {
 func (l *Ledger) AddTransaction(tx Transaction) error {
 	err := l.graph.AddTransaction(tx)
 
-	if err != nil && errors.Cause(err) != ErrAlreadyExists {
+	// Ignore error if transaction already exists,
+	// or transaction's depth is too low due to pruning
+	if err != nil &&
+		errors.Cause(err) != ErrAlreadyExists &&
+		errors.Cause(err) != ErrDepthTooLow {
+
 		return err
 	}
 

--- a/ledger.go
+++ b/ledger.go
@@ -25,12 +25,13 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"github.com/perlin-network/wavelet/conf"
-	"github.com/perlin-network/wavelet/lru"
 	"math/rand"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/perlin-network/wavelet/conf"
+	"github.com/perlin-network/wavelet/lru"
 
 	"github.com/perlin-network/noise"
 	"github.com/perlin-network/noise/skademlia"

--- a/ledger_test.go
+++ b/ledger_test.go
@@ -411,6 +411,12 @@ func TestLedger_DownloadMissingTx(t *testing.T) {
 		stops[node.PublicKey()] = startBenchmark(node)
 	}
 
+	defer func() {
+		for _, stop := range stops {
+			close(stop)
+		}
+	}()
+
 	for {
 		alice.WaitUntilConsensus(t)
 		fmt.Println("consensus round", alice.RoundIndex())

--- a/ledger_test.go
+++ b/ledger_test.go
@@ -1,6 +1,7 @@
 package wavelet
 
 import (
+	"encoding/hex"
 	"fmt"
 	"os"
 	"sync"
@@ -356,101 +357,80 @@ func TestLedger_SpamContracts(t *testing.T) {
 	alice.WaitUntilConsensus(t)
 }
 
-// func TestLedger_DownloadMissingTx(t *testing.T) {
-// 	testnet := NewTestNetwork(t)
-// 	defer testnet.Cleanup()
-//
-// 	nodes := 3
-// 	initialRounds := 70
-// 	// postLeaveRounds := 10
-//
-// 	for i := 0; i < nodes-1; i++ {
-// 		testnet.AddNode(t)
-// 	}
-//
-// 	alice := testnet.Faucet()
-// 	stop := make(chan struct{})
-// 	go func() {
-// 		for {
-// 			select {
-// 			case <-stop:
-// 				return
-//
-// 			default:
-// 				assert.NoError(t, txError(alice.Benchmark()))
-// 			}
-// 		}
-// 	}()
-//
-// 	var info *FinalizeRoundResult
-//
-// 	for {
-// 		alice.WaitUntilConsensus(t)
-//
-// 		waitFor(t, func() bool {
-// 			info = alice.ledger.FinalizeRoundInfo(alice.RoundIndex())
-// 			return info != nil
-// 		})
-//
-// 		fmt.Printf("consensus round, index=%d, applied=%d, ignored=%d, rejected=%d, missing=%d, incomplete=%d\n",
-// 			alice.RoundIndex(), info.AppliedTxCount, info.IgnoredTxCount, info.RejectedTxCount,
-// 			alice.ledger.Graph().MissingLen(), alice.ledger.Graph().IncompleteLen())
-//
-// 		if alice.RoundIndex() >= uint64(initialRounds) {
-// 			break
-// 		}
-// 	}
-//
-// 	time.Sleep(time.Second * 1)
-//
-// 	bob := testnet.Nodes()[nodes-1]
-// 	bobKey := bob.PrivateKey()
-//
-// 	fmt.Println("bob left")
-//
-// 	bob.Cleanup()
-// 	testnet.nodes = testnet.nodes[:nodes-1]
-//
-// 	time.Sleep(time.Second * 1)
-//
-// 	// for {
-// 	// 	alice.WaitUntilConsensus(t)
-//
-// 	// 	waitFor(t, func() bool {
-// 	// 		info = alice.ledger.FinalizeRoundInfo(alice.RoundIndex())
-// 	// 		return info != nil
-// 	// 	})
-//
-// 	// 	fmt.Printf("consensus round, index=%d, applied=%d, ignored=%d, rejected=%d, missing=%d, incomplete=%d\n",
-// 	// 		alice.RoundIndex(), info.AppliedTxCount, info.IgnoredTxCount, info.RejectedTxCount,
-// 	// 		alice.ledger.Graph().MissingLen(), alice.ledger.Graph().IncompleteLen())
-//
-// 	// 	if alice.RoundIndex() >= uint64(initialRounds+postLeaveRounds) {
-// 	// 		break
-// 	// 	}
-// 	// }
-//
-// 	time.Sleep(time.Second * 5)
-//
-// 	fmt.Println("benchmark stopped")
-// 	close(stop)
-//
-// 	bob = testnet.AddNode(t, TestWithWallet(hex.EncodeToString(bobKey[:])))
-//
-// 	fmt.Printf("bob rejoined, index=%d, missing=%d, incomplete=%d\n",
-// 		bob.RoundIndex(), bob.ledger.Graph().MissingLen(), bob.ledger.Graph().IncompleteLen())
-//
-// 	time.Sleep(time.Second * 10)
-//
-// 	// log.SetWriter(log.ModuleNode, os.Stdout)
-//
-// 	// Wait for no more missing txs
-// 	waitForDuration(t, func() bool {
-// 		fmt.Printf("bob status, index=%d, missing=%d, incomplete=%d\n",
-// 			bob.RoundIndex(), bob.ledger.Graph().MissingLen(), bob.ledger.Graph().IncompleteLen())
-// 		return bob.ledger.Graph().MissingLen() == 0
-// 	}, time.Minute*5)
-// }
+func TestLedger_DownloadMissingTx2(t *testing.T) {
+	conf.Update(conf.WithSyncIfRoundsDifferBy(2))
+
+	testnet := NewTestNetwork(t)
+	defer testnet.Cleanup()
+
+	nodes := 4
+	initialRounds := 70
+	// postLeaveRounds := 10
+
+	for i := 0; i < nodes-1; i++ {
+		testnet.AddNode(t)
+	}
+
+	alice := testnet.Faucet()
+
+	startBenchmark := func(n *TestLedger) chan struct{} {
+		stop := make(chan struct{})
+		go func() {
+			for {
+				select {
+				case <-stop:
+					return
+
+				default:
+					assert.NoError(t, txError(n.Benchmark()))
+				}
+			}
+		}()
+		return stop
+	}
+
+	stops := make([]chan struct{}, len(testnet.Nodes()))
+	for i, node := range testnet.Nodes() {
+		stops[i] = startBenchmark(node)
+	}
+
+	for {
+		alice.WaitUntilConsensus(t)
+		fmt.Println("consensus round", alice.RoundIndex())
+		if alice.RoundIndex() >= uint64(initialRounds) {
+			break
+		}
+	}
+
+	time.Sleep(time.Second * 1)
+
+	bob := testnet.Nodes()[nodes-1]
+	bobKey := bob.PrivateKey()
+
+	fmt.Println("bob left")
+
+	// close(stops[nodes-1])
+	bob.Cleanup()
+	testnet.nodes = testnet.nodes[:nodes-1]
+
+	// time.Sleep(time.Second * 5)
+
+	bob = testnet.AddNode(t, TestWithWallet(hex.EncodeToString(bobKey[:])))
+
+	fmt.Printf("bob rejoined, index=%d, missing=%d, incomplete=%d\n",
+		bob.RoundIndex(), bob.ledger.Graph().MissingLen(), bob.ledger.Graph().IncompleteLen())
+
+	time.Sleep(time.Second * 10)
+
+	// log.SetWriter(log.ModuleNode, os.Stdout)
+
+	// Wait for no more missing txs
+	waitForDuration(t, func() bool {
+		fmt.Printf("bob status, index=%d, missing=%d, incomplete=%d\n",
+			bob.RoundIndex(), bob.ledger.Graph().MissingLen(), bob.ledger.Graph().IncompleteLen())
+		return bob.ledger.Graph().MissingLen() == 0
+	}, time.Minute*5)
+}
 
 func TestLedger_DownloadMissingTx(t *testing.T) {
 	testnet := NewTestNetwork(t)

--- a/ledger_test.go
+++ b/ledger_test.go
@@ -431,6 +431,7 @@ func TestLedger_DownloadMissingTx(t *testing.T) {
 
 	// Make bob leave and stop the benchmark on his node
 	close(stops[bob.PublicKey()])
+	delete(stops, bob.PublicKey())
 	bob.Leave()
 
 	time.Sleep(time.Second * 1)

--- a/store/testutil.go
+++ b/store/testutil.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"os"
 	"testing"
 )
 
@@ -18,7 +17,7 @@ func NewTestKV(t testing.TB, kv string, path string) (KV, func()) {
 
 	case "level":
 		// Remove existing db
-		_ = os.RemoveAll(path)
+		// _ = os.RemoveAll(path)
 
 		leveldb, err := NewLevelDB(path)
 		if err != nil {
@@ -27,7 +26,7 @@ func NewTestKV(t testing.TB, kv string, path string) (KV, func()) {
 
 		return leveldb, func() {
 			_ = leveldb.Close()
-			_ = os.RemoveAll(path)
+			// _ = os.RemoveAll(path)
 		}
 
 	default:

--- a/testutil.go
+++ b/testutil.go
@@ -404,6 +404,23 @@ func (l *TestLedger) WaitForRound(index uint64) <-chan uint64 {
 	return ch
 }
 
+func (l *TestLedger) WaitUntilRound(t testing.TB, round uint64) {
+	t.Helper()
+
+	timeout := time.NewTimer(time.Second * 30)
+	for {
+		select {
+		case ri := <-l.WaitForRound(round):
+			if ri >= round {
+				return
+			}
+
+		case <-timeout.C:
+			t.Fatal("timed out waiting for round")
+		}
+	}
+}
+
 func (l *TestLedger) WaitForSync() <-chan bool {
 	ch := make(chan bool)
 	go func() {

--- a/testutil.go
+++ b/testutil.go
@@ -75,6 +75,11 @@ func (n *TestNetwork) Cleanup() {
 	for _, node := range n.nodes {
 		node.Cleanup()
 	}
+
+	// Remove db
+	for i := 0; i < 20; i++ {
+		_ = os.RemoveAll(fmt.Sprintf("db_%d", i))
+	}
 }
 
 func (n *TestNetwork) Faucet() *TestLedger {

--- a/testutil.go
+++ b/testutil.go
@@ -336,7 +336,6 @@ func (l *TestLedger) Cleanup() {
 	l.server.Stop()
 	<-l.stopped
 
-	l.ledger.Close()
 	l.kvCleanup()
 }
 


### PR DESCRIPTION
If a transaction depth is too low due to pruning, the transaction is now ignored.