### PR TITLE
Cleanup ledger.

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -45,7 +45,10 @@ func NewAccounts(kv store.KV) *Accounts {
 
 // GC periodically garbage collects every 5 seconds. Only one
 // instance of GC worker can run at any time.
-func (a *Accounts) GC(ctx context.Context) {
+func (a *Accounts) GC(ctx context.Context, wg *sync.WaitGroup) {
+	wg.Add(1)
+	defer wg.Done()
+
 	timer := time.NewTicker(5 * time.Second)
 	defer timer.Stop()
 

--- a/api/mod.go
+++ b/api/mod.go
@@ -25,14 +25,20 @@ import (
 	"crypto/tls"
 	"encoding/hex"
 	"fmt"
-	"github.com/perlin-network/wavelet/store"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
 	"os"
+	"strconv"
+	"time"
 
 	"github.com/buaazp/fasthttprouter"
 	"github.com/perlin-network/noise/skademlia"
 	"github.com/perlin-network/wavelet"
 	"github.com/perlin-network/wavelet/debounce"
 	"github.com/perlin-network/wavelet/log"
+	"github.com/perlin-network/wavelet/store"
 	"github.com/perlin-network/wavelet/sys"
 	"github.com/pkg/errors"
 	"github.com/valyala/fasthttp"
@@ -40,13 +46,6 @@ import (
 	"github.com/valyala/fastjson"
 	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/acme/autocert"
-	"net"
-
-	"io"
-	"net/http"
-	"net/url"
-	"strconv"
-	"time"
 )
 
 type Gateway struct {

--- a/cmd/wavelet/cli.go
+++ b/cmd/wavelet/cli.go
@@ -29,6 +29,7 @@ import (
 	"github.com/benpye/readline"
 	"github.com/perlin-network/noise/skademlia"
 	"github.com/perlin-network/wavelet"
+	"github.com/perlin-network/wavelet/api"
 	"github.com/perlin-network/wavelet/conf"
 	"github.com/perlin-network/wavelet/log"
 	"github.com/perlin-network/wavelet/store"
@@ -44,14 +45,15 @@ const (
 )
 
 type CLI struct {
-	app    *cli.App
-	rl     *readline.Instance
-	client *skademlia.Client
-	server *grpc.Server
-	ledger *wavelet.Ledger
-	logger zerolog.Logger
-	keys   *skademlia.Keypair
-	kv     store.KV
+	app     *cli.App
+	rl      *readline.Instance
+	client  *skademlia.Client
+	server  *grpc.Server
+	gateway *api.Gateway
+	ledger  *wavelet.Ledger
+	logger  zerolog.Logger
+	keys    *skademlia.Keypair
+	kv      store.KV
 
 	completion []string
 }
@@ -59,6 +61,7 @@ type CLI struct {
 func NewCLI(
 	client *skademlia.Client,
 	server *grpc.Server,
+	gateway *api.Gateway,
 	ledger *wavelet.Ledger,
 	keys *skademlia.Keypair,
 	stdin io.ReadCloser,
@@ -66,13 +69,14 @@ func NewCLI(
 	kv store.KV,
 ) (*CLI, error) {
 	c := &CLI{
-		client: client,
-		server: server,
-		ledger: ledger,
-		logger: log.Node(),
-		keys:   keys,
-		app:    cli.NewApp(),
-		kv:     kv,
+		client:  client,
+		server:  server,
+		gateway: gateway,
+		ledger:  ledger,
+		logger:  log.Node(),
+		keys:    keys,
+		app:     cli.NewApp(),
+		kv:      kv,
 	}
 
 	c.app.Name = "wavelet"
@@ -374,6 +378,7 @@ ReadLoop:
 
 	_ = cli.rl.Close()
 
+	cli.gateway.Shutdown()
 	cli.server.GracefulStop()
 	cli.ledger.Close()
 	cli.kv.Close()

--- a/cmd/wavelet/cli.go
+++ b/cmd/wavelet/cli.go
@@ -34,6 +34,7 @@ import (
 	"github.com/perlin-network/wavelet/store"
 	"github.com/rs/zerolog"
 	"github.com/urfave/cli"
+	"google.golang.org/grpc"
 )
 
 const (
@@ -46,6 +47,7 @@ type CLI struct {
 	app    *cli.App
 	rl     *readline.Instance
 	client *skademlia.Client
+	server *grpc.Server
 	ledger *wavelet.Ledger
 	logger zerolog.Logger
 	keys   *skademlia.Keypair
@@ -56,6 +58,7 @@ type CLI struct {
 
 func NewCLI(
 	client *skademlia.Client,
+	server *grpc.Server,
 	ledger *wavelet.Ledger,
 	keys *skademlia.Keypair,
 	stdin io.ReadCloser,
@@ -64,6 +67,7 @@ func NewCLI(
 ) (*CLI, error) {
 	c := &CLI{
 		client: client,
+		server: server,
 		ledger: ledger,
 		logger: log.Node(),
 		keys:   keys,
@@ -369,7 +373,10 @@ ReadLoop:
 	}
 
 	_ = cli.rl.Close()
+
+	cli.server.GracefulStop()
 	cli.ledger.Close()
+	cli.kv.Close()
 }
 
 func (cli *CLI) exit(ctx *cli.Context) {

--- a/cmd/wavelet/cli.go
+++ b/cmd/wavelet/cli.go
@@ -369,6 +369,7 @@ ReadLoop:
 	}
 
 	_ = cli.rl.Close()
+	cli.ledger.Close()
 }
 
 func (cli *CLI) exit(ctx *cli.Context) {

--- a/cmd/wavelet/main.go
+++ b/cmd/wavelet/main.go
@@ -397,10 +397,9 @@ func start(cfg *Config, stdin io.ReadCloser, stdout io.Writer) {
 	}
 
 	ledger := wavelet.NewLedger(kv, client, opts...)
+	server := client.Listen()
 
 	go func() {
-		server := client.Listen()
-
 		wavelet.RegisterWaveletServer(server, ledger.Protocol())
 
 		if err := server.Serve(listener); err != nil {
@@ -429,11 +428,10 @@ func start(cfg *Config, stdin io.ReadCloser, stdout io.Writer) {
 	} else {
 		if cfg.APIPort > 0 {
 			go api.New().StartHTTP(int(cfg.APIPort), client, ledger, keys, kv)
-
 		}
 	}
 
-	shell, err := NewCLI(client, ledger, keys, stdin, stdout, kv)
+	shell, err := NewCLI(client, server, ledger, keys, stdin, stdout, kv)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("Failed to create CLI.")
 	}

--- a/cmd/wavelet/main.go
+++ b/cmd/wavelet/main.go
@@ -423,15 +423,16 @@ func start(cfg *Config, stdin io.ReadCloser, stdout io.Writer) {
 		logger.Info().Msgf("Bootstrapped with peers: %+v", ids)
 	}
 
+	gateway := api.New()
 	if cfg.APIHost != nil {
-		go api.New().StartHTTPS(int(cfg.APIPort), client, ledger, keys, kv, *cfg.APIHost, *cfg.APICertsCache)
+		go gateway.StartHTTPS(int(cfg.APIPort), client, ledger, keys, kv, *cfg.APIHost, *cfg.APICertsCache)
 	} else {
 		if cfg.APIPort > 0 {
-			go api.New().StartHTTP(int(cfg.APIPort), client, ledger, keys, kv)
+			go gateway.StartHTTP(int(cfg.APIPort), client, ledger, keys, kv)
 		}
 	}
 
-	shell, err := NewCLI(client, server, ledger, keys, stdin, stdout, kv)
+	shell, err := NewCLI(client, server, gateway, ledger, keys, stdin, stdout, kv)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("Failed to create CLI.")
 	}

--- a/cmd/wavelet/main_test.go
+++ b/cmd/wavelet/main_test.go
@@ -27,7 +27,7 @@ var wallet1 = "87a6813c3b4cf534b6ae82db9b1409fa7dbd5c13dba5858970b56084c4a930eb4
 var wallet2 = "85e7450f7cf0d9cd1d1d7bf4169c2f364eea4ba833a7280e0f931a1d92fd92c2696937c2c8df35dba0169de72990b80761e51dd9e2411fa1fce147f68ade830a"
 
 func TestMain(t *testing.T) {
-	w := NewTestWavelet(t, nil)
+	w := NewTestWavelet(t, defaultConfig())
 	defer w.Cleanup()
 
 	ledger := w.GetLedgerStatus(t)
@@ -36,7 +36,9 @@ func TestMain(t *testing.T) {
 }
 
 func TestMain_WithLogLevel(t *testing.T) {
-	w := NewTestWavelet(t, &TestWaveletConfig{LogLevel: "warn"})
+	config := defaultConfig()
+	config.LogLevel = "warn"
+	w := NewTestWavelet(t, config)
 	defer w.Cleanup()
 
 	w.Stdin <- "status"
@@ -60,7 +62,9 @@ func TestMain_WithLogLevel(t *testing.T) {
 func TestMain_WithInvalidLogLevel(t *testing.T) {
 	// Invalid loglevel will cause the ledger to use the default log level,
 	// which is debug
-	w := NewTestWavelet(t, &TestWaveletConfig{LogLevel: "foobar"})
+	config := defaultConfig()
+	config.LogLevel = "foobar"
+	w := NewTestWavelet(t, config)
 	defer w.Cleanup()
 
 	w.Stdin <- "status"
@@ -68,12 +72,13 @@ func TestMain_WithInvalidLogLevel(t *testing.T) {
 }
 
 func TestMain_WithWalletString(t *testing.T) {
-	wallet := "b27b880e6e44e3b127186a08bc5698316e8dd99157cec56211560b62141f0851c72096021609681eb8cab244752945b2008e1b51d8bc2208b2b562f35485d5cc"
-	w := NewTestWavelet(t, &TestWaveletConfig{Wallet: wallet})
+	config := defaultConfig()
+	config.Wallet = "b27b880e6e44e3b127186a08bc5698316e8dd99157cec56211560b62141f0851c72096021609681eb8cab244752945b2008e1b51d8bc2208b2b562f35485d5cc"
+	w := NewTestWavelet(t, config)
 	defer w.Cleanup()
 
 	ledger := w.GetLedgerStatus(t)
-	assert.EqualValues(t, wallet[64:], ledger.PublicKey)
+	assert.EqualValues(t, config.Wallet[64:], ledger.PublicKey)
 }
 
 func TestMain_WithWalletFile(t *testing.T) {
@@ -91,7 +96,9 @@ func TestMain_WithWalletFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	w := NewTestWavelet(t, &TestWaveletConfig{Wallet: walletPath})
+	config := defaultConfig()
+	config.Wallet = walletPath
+	w := NewTestWavelet(t, config)
 	defer w.Cleanup()
 
 	ledger := w.GetLedgerStatus(t)
@@ -99,8 +106,9 @@ func TestMain_WithWalletFile(t *testing.T) {
 }
 
 func TestMain_WithInvalidWallet(t *testing.T) {
-	wallet := "foobar"
-	w := NewTestWavelet(t, &TestWaveletConfig{Wallet: wallet})
+	config := defaultConfig()
+	config.Wallet = "foobar"
+	w := NewTestWavelet(t, config)
 	defer w.Cleanup()
 
 	ledger := w.GetLedgerStatus(t)
@@ -108,7 +116,7 @@ func TestMain_WithInvalidWallet(t *testing.T) {
 }
 
 func TestMain_Status(t *testing.T) {
-	w := NewTestWavelet(t, nil)
+	w := NewTestWavelet(t, defaultConfig())
 	defer w.Cleanup()
 
 	w.Stdin <- "status"
@@ -116,7 +124,9 @@ func TestMain_Status(t *testing.T) {
 }
 
 func TestMain_Pay(t *testing.T) {
-	alice := NewTestWavelet(t, &TestWaveletConfig{Wallet: wallet2})
+	config := defaultConfig()
+	config.Wallet = wallet2
+	alice := NewTestWavelet(t, config)
 	defer alice.Cleanup()
 
 	bob := alice.Testnet.AddNode(t)
@@ -137,7 +147,9 @@ func TestMain_Pay(t *testing.T) {
 }
 
 func TestMain_Spawn(t *testing.T) {
-	w := NewTestWavelet(t, &TestWaveletConfig{Wallet: wallet2})
+	config := defaultConfig()
+	config.Wallet = wallet2
+	w := NewTestWavelet(t, config)
 	defer w.Cleanup()
 
 	for i := 0; i < 3; i++ {
@@ -157,7 +169,9 @@ func TestMain_Spawn(t *testing.T) {
 }
 
 func TestMain_Call(t *testing.T) {
-	w := NewTestWavelet(t, &TestWaveletConfig{Wallet: wallet2})
+	config := defaultConfig()
+	config.Wallet = wallet2
+	w := NewTestWavelet(t, config)
 	defer w.Cleanup()
 
 	for i := 0; i < 3; i++ {
@@ -178,7 +192,9 @@ func TestMain_Call(t *testing.T) {
 }
 
 func TestMain_CallWithParams(t *testing.T) {
-	w := NewTestWavelet(t, &TestWaveletConfig{Wallet: wallet2})
+	config := defaultConfig()
+	config.Wallet = wallet2
+	w := NewTestWavelet(t, config)
 	defer w.Cleanup()
 
 	for i := 0; i < 3; i++ {
@@ -249,7 +265,9 @@ func TestMain_CallWithParams(t *testing.T) {
 }
 
 func TestMain_DepositGas(t *testing.T) {
-	w := NewTestWavelet(t, &TestWaveletConfig{Wallet: wallet2})
+	config := defaultConfig()
+	config.Wallet = wallet2
+	w := NewTestWavelet(t, config)
 	defer w.Cleanup()
 
 	for i := 0; i < 3; i++ {
@@ -270,7 +288,9 @@ func TestMain_DepositGas(t *testing.T) {
 }
 
 func TestMain_Find(t *testing.T) {
-	alice := NewTestWavelet(t, &TestWaveletConfig{Wallet: wallet2})
+	config := defaultConfig()
+	config.Wallet = wallet2
+	alice := NewTestWavelet(t, config)
 	defer alice.Cleanup()
 
 	bob := alice.Testnet.AddNode(t)
@@ -288,7 +308,9 @@ func TestMain_Find(t *testing.T) {
 }
 
 func TestMain_PlaceStake(t *testing.T) {
-	alice := NewTestWavelet(t, &TestWaveletConfig{Wallet: wallet2})
+	config := defaultConfig()
+	config.Wallet = wallet2
+	alice := NewTestWavelet(t, config)
 	defer alice.Cleanup()
 
 	bob := alice.Testnet.AddNode(t)
@@ -309,7 +331,9 @@ func TestMain_PlaceStake(t *testing.T) {
 }
 
 func TestMain_WithdrawStake(t *testing.T) {
-	alice := NewTestWavelet(t, &TestWaveletConfig{Wallet: wallet2})
+	config := defaultConfig()
+	config.Wallet = wallet2
+	alice := NewTestWavelet(t, config)
 	defer alice.Cleanup()
 
 	bob := alice.Testnet.AddNode(t)
@@ -337,7 +361,9 @@ func TestMain_WithdrawStake(t *testing.T) {
 }
 
 func TestMain_WithdrawReward(t *testing.T) {
-	w := NewTestWavelet(t, &TestWaveletConfig{Wallet: wallet2})
+	config := defaultConfig()
+	config.Wallet = wallet2
+	w := NewTestWavelet(t, config)
 	defer w.Cleanup()
 
 	for i := 0; i < 3; i++ {
@@ -359,7 +385,7 @@ func TestMain_WithdrawReward(t *testing.T) {
 }
 
 func TestMain_UpdateParams(t *testing.T) {
-	w := NewTestWavelet(t, nil)
+	w := NewTestWavelet(t, defaultConfig())
 	defer w.Cleanup()
 
 	w.Stdin <- "up"
@@ -371,7 +397,6 @@ func TestMain_UpdateParams(t *testing.T) {
 		Value  interface{}
 	}{
 		{"snowball.k", "snowballK", int(123)},
-		{"snowball.alpha", "snowballAlpha", float64(456)},
 		{"snowball.beta", "snowballBeta", int(789)},
 		{"query.timeout", "queryTimeout", time.Second * 9},
 		{"gossip.timeout", "gossipTimeout", time.Second * 4},
@@ -423,7 +448,7 @@ func TestMain_UpdateParams(t *testing.T) {
 }
 
 func TestMain_ConnectDisconnect(t *testing.T) {
-	w := NewTestWavelet(t, nil)
+	w := NewTestWavelet(t, defaultConfig())
 	defer w.Cleanup()
 
 	peer := w.Testnet.AddNode(t)
@@ -602,6 +627,12 @@ func (w *TestWavelet) Cleanup() {
 type TestWaveletConfig struct {
 	Wallet   string
 	LogLevel string
+}
+
+func defaultConfig() *TestWaveletConfig {
+	return &TestWaveletConfig{
+		LogLevel: "info",
+	}
 }
 
 func NewTestWavelet(t *testing.T, cfg *TestWaveletConfig) *TestWavelet {

--- a/ledger.go
+++ b/ledger.go
@@ -225,7 +225,10 @@ func (l *Ledger) Close() {
 	l.consensus.Wait()
 
 	close(l.stop)
-	l.cancelGC()
+
+	if l.cancelGC != nil {
+		l.cancelGC()
+	}
 }
 
 // AddTransaction adds a transaction to the ledger. If the transaction has

--- a/log/mod.go
+++ b/log/mod.go
@@ -76,18 +76,21 @@ func setupChildLoggers() {
 	metrics = logger.With().Str(KeyModule, ModuleMetrics).Logger()
 }
 
-func SetLevel(level string) {
-	if l, err := zerolog.ParseLevel(level); err == nil {
-		node = node.Level(l)
-		network = network.Level(l)
-		accounts = accounts.Level(l)
-		consensus = consensus.Level(l)
-		contract = contract.Level(l)
-		syncer = syncer.Level(l)
-		stake = stake.Level(l)
-		tx = tx.Level(l)
-		metrics = metrics.Level(l)
+func SetLevel(ls string) {
+	level, err := zerolog.ParseLevel(ls)
+	if err != nil {
+		level = zerolog.DebugLevel
 	}
+
+	node = node.Level(level)
+	network = network.Level(level)
+	accounts = accounts.Level(level)
+	consensus = consensus.Level(level)
+	contract = contract.Level(level)
+	syncer = syncer.Level(level)
+	stake = stake.Level(level)
+	tx = tx.Level(level)
+	metrics = metrics.Level(level)
 }
 
 func SetWriter(key string, writer io.Writer) {

--- a/recovery.go
+++ b/recovery.go
@@ -2,13 +2,14 @@ package wavelet
 
 import (
 	"fmt"
-	"github.com/perlin-network/wavelet/log"
-	"github.com/pkg/errors"
 	"os"
 	"runtime"
 	"runtime/pprof"
 	"sync"
 	"time"
+
+	"github.com/perlin-network/wavelet/log"
+	"github.com/pkg/errors"
 )
 
 type StallDetector struct {
@@ -41,7 +42,10 @@ func NewStallDetector(stop <-chan struct{}, config StallDetectorConfig, delegate
 	}
 }
 
-func (d *StallDetector) Run() {
+func (d *StallDetector) Run(wg *sync.WaitGroup) {
+	wg.Add(1)
+	defer wg.Done()
+
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 

--- a/testutil.go
+++ b/testutil.go
@@ -336,6 +336,7 @@ func (l *TestLedger) Cleanup() {
 	l.server.Stop()
 	<-l.stopped
 
+	l.ledger.Close()
 	l.kvCleanup()
 }
 


### PR DESCRIPTION
Refer to #181. Having proper cleanup will make our tests more robust, as currently tests may sometimes fail as it's possible for different instances of `Ledger` to interact with each other between tests. This usually happens with tests in `cmd/wavelet` package.

Things to do when stopping wavelet:
- [cli] Stop API server
- [cli] Stop GRPC (close all client connections, and then the server)
- [ledger] Stop all consensus-related goroutines
- [ledger] Stop GC goroutine (if enabled)
- [ledger] Stop stall detector goroutine
- [ledger] Wait for all of the goroutines above to complete
- [cli] Close KV

TODO:
- [ ] Handle `SIGTERM` and `SIGINT`
- [ ] Handle close when restarting node via `StallDetector`