### PR TITLE
Improve error message of cmd/wavelet

### DIFF
--- a/cmd/wavelet/main.go
+++ b/cmd/wavelet/main.go
@@ -297,7 +297,7 @@ func start(cfg *Config, stdin io.ReadCloser, stdout io.Writer) {
 
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.Port))
 	if err != nil {
-		panic(err)
+		logger.Fatal().Err(err).Msgf("Failed to listen to port %d.", cfg.Port)
 	}
 
 	addr := net.JoinHostPort(cfg.Host, strconv.Itoa(listener.Addr().(*net.TCPAddr).Port))
@@ -311,22 +311,22 @@ func start(cfg *Config, stdin io.ReadCloser, stdout io.Writer) {
 				uint16(listener.Addr().(*net.TCPAddr).Port),
 				30*time.Minute,
 			); err != nil {
-				panic(err)
+				logger.Fatal().Err(err).Msg("Failed to add mapping.")
 			}
 		}
 
 		resp, err := http.Get("http://myexternalip.com/raw")
 		if err != nil {
-			panic(err)
+			logger.Fatal().Err(err).Msg("Failed to get external IP.")
 		}
 
 		ip, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			panic(err)
+			logger.Fatal().Err(err).Msg("Failed to read external IP response body.")
 		}
 
 		if err := resp.Body.Close(); err != nil {
-			panic(err)
+			logger.Fatal().Err(err).Msg("Failed to close external IP response body.")
 		}
 
 		addr = net.JoinHostPort(string(ip), strconv.Itoa(listener.Addr().(*net.TCPAddr).Port))
@@ -336,7 +336,7 @@ func start(cfg *Config, stdin io.ReadCloser, stdout io.Writer) {
 
 	keys, err := keys(cfg.Wallet)
 	if err != nil {
-		panic(err)
+		logger.Fatal().Err(err).Msg("Failed to setup wallet.")
 	}
 
 	client := skademlia.NewClient(
@@ -393,7 +393,7 @@ func start(cfg *Config, stdin io.ReadCloser, stdout io.Writer) {
 		wavelet.RegisterWaveletServer(server, ledger.Protocol())
 
 		if err := server.Serve(listener); err != nil {
-			panic(err)
+			logger.Fatal().Err(err).Msg("Failed to start Wavelet server.")
 		}
 	}()
 
@@ -424,7 +424,7 @@ func start(cfg *Config, stdin io.ReadCloser, stdout io.Writer) {
 
 	shell, err := NewCLI(client, ledger, keys, stdin, stdout, kv)
 	if err != nil {
-		panic(err)
+		logger.Fatal().Err(err).Msg("Failed to create CLI.")
 	}
 
 	shell.Start()

--- a/cmd/wavelet/main.go
+++ b/cmd/wavelet/main.go
@@ -21,8 +21,8 @@ package main
 
 import (
 	"encoding/hex"
-	"errors"
 	"fmt"
+	"github.com/pkg/errors"
 	"io"
 	"io/ioutil"
 	"net"
@@ -442,16 +442,16 @@ func keys(wallet string) (*skademlia.Keypair, error) {
 
 		n, err := hex.Decode(privateKey[:], privateKeyBuf)
 		if err != nil {
-			return nil, fmt.Errorf("failed to decode your private key from %q", wallet)
+			return nil, errors.Wrapf(err, "failed to decode your private key from %q", wallet)
 		}
 
 		if n != edwards25519.SizePrivateKey {
-			return nil, fmt.Errorf("private key located in %q is not of the right length", wallet)
+			return nil, errors.Errorf("private key located in %q is not of the right length", wallet)
 		}
 
 		keys, err = skademlia.LoadKeys(privateKey, sys.SKademliaC1, sys.SKademliaC2)
 		if err != nil {
-			return nil, fmt.Errorf("the private key specified in %q is invalid", wallet)
+			return nil, errors.Wrapf(err, "the private key specified in %q is invalid", wallet)
 		}
 
 		publicKey := keys.PublicKey()
@@ -471,16 +471,16 @@ func keys(wallet string) (*skademlia.Keypair, error) {
 
 			n, err := hex.Decode(privateKey[:], []byte(wallet))
 			if err != nil {
-				return nil, fmt.Errorf("failed to decode the private key specified: %s", wallet)
+				return nil, errors.Wrapf(err, "failed to decode the private key specified: %s", wallet)
 			}
 
 			if n != edwards25519.SizePrivateKey {
-				return nil, fmt.Errorf("private key %s is not of the right length", wallet)
+				return nil, errors.Errorf("private key %s is not of the right length", wallet)
 			}
 
 			keys, err = skademlia.LoadKeys(privateKey, sys.SKademliaC1, sys.SKademliaC2)
 			if err != nil {
-				return nil, fmt.Errorf("the private key specified is invalid: %s", wallet)
+				return nil, errors.Wrapf(err, "the private key specified is invalid: %s", wallet)
 			}
 
 			publicKey := keys.PublicKey()
@@ -495,7 +495,7 @@ func keys(wallet string) (*skademlia.Keypair, error) {
 
 		keys, err = skademlia.NewKeys(sys.SKademliaC1, sys.SKademliaC2)
 		if err != nil {
-			return nil, errors.New("failed to generate a new wallet")
+			return nil, errors.Wrapf(err, "failed to generate a new wallet")
 		}
 
 		privateKey := keys.PrivateKey()


### PR DESCRIPTION
Make the error returned by `keys()` more debuggable by wrapping the errors instead of returning new errors.