### PR TITLE
Use larger buffers for gRPC, to accomodate larger syncs

### DIFF
--- a/cmd/wavelet/main.go
+++ b/cmd/wavelet/main.go
@@ -343,7 +343,11 @@ func start(cfg *Config, stdin io.ReadCloser, stdout io.Writer) {
 		addr, keys,
 		skademlia.WithC1(sys.SKademliaC1),
 		skademlia.WithC2(sys.SKademliaC2),
-		skademlia.WithDialOptions(grpc.WithDefaultCallOptions(grpc.UseCompressor(snappy.Name))),
+		skademlia.WithDialOptions(grpc.WithDefaultCallOptions(
+			grpc.UseCompressor(snappy.Name),
+			grpc.MaxCallRecvMsgSize(9 * 1024 * 1024),
+			grpc.MaxCallSendMsgSize(3 * 1024 * 1024),
+		)),
 	)
 
 	client.SetCredentials(noise.NewCredentials(addr, handshake.NewECDH(), cipher.NewAEAD(), client.Protocol()))


### PR DESCRIPTION
Currently sync responses are limited to 4MB.  Under extreme conditions the responses may be larger.  Extend the buffer size to accommodate these cases.