### PR TITLE
Speed up finding number of peers

### DIFF
--- a/ledger.go
+++ b/ledger.go
@@ -639,7 +639,7 @@ FINALIZE_ROUNDS:
 		default:
 		}
 
-		if len(l.client.ClosestPeers()) < conf.GetSnowballK() {
+		if len(l.client.ClosestPeerIDs()) < conf.GetSnowballK() {
 			select {
 			case <-l.sync:
 				return


### PR DESCRIPTION
ClosestPeers() tries to connect to all the peers, if they are down then this takes a long time.  ClosestPeerIDs() just returns the count of items in the table