### PR TITLE
Improve delays

### DIFF
--- a/ledger.go
+++ b/ledger.go
@@ -673,7 +673,7 @@ FINALIZE_ROUNDS:
 				select {
 				case <-l.sync:
 					return
-				case <-time.After(1 * time.Millisecond):
+				case <-time.After(100 * time.Millisecond):
 				}
 
 				continue FINALIZE_ROUNDS
@@ -977,6 +977,8 @@ func (l *Ledger) SyncToLatestRound() {
 	syncTimeoutMultiplier := 0
 	for {
 		for {
+			time.Sleep(5 * time.Millisecond)
+
 			conns, err := SelectPeers(l.client.ClosestPeers(), conf.GetSnowballK())
 			if err != nil {
 				select {


### PR DESCRIPTION
When broadcasting nops, it is not beneficial to wait less than 100ms before retrying since there is a check to ensure that nops are not emitted faster than that

Also wait a bit between attempts to connect to all peers