### PR TITLE
Increase the size of the mockStdout buffer

### DIFF
--- a/cmd/wavelet/main_test.go
+++ b/cmd/wavelet/main_test.go
@@ -540,7 +540,7 @@ type mockStdout struct {
 
 func newMockStdout() *mockStdout {
 	return &mockStdout{
-		Lines: make(chan string, 256),
+		Lines: make(chan string, 16384),
 		buf:   make([]byte, 0),
 	}
 }


### PR DESCRIPTION
As we write more and more debugging/informational logs the existing buffer may get full