### PR TITLE
Fix the tests in main_test.go

### DIFF
--- a/cmd/wavelet/main_test.go
+++ b/cmd/wavelet/main_test.go
@@ -540,7 +540,7 @@ type mockStdout struct {
 
 func newMockStdout() *mockStdout {
 	return &mockStdout{
-		Lines: make(chan string, 256),
+		Lines: make(chan string, 256*1024),
 		buf:   make([]byte, 0),
 	}
 }

--- a/cmd/wavelet/main_test.go
+++ b/cmd/wavelet/main_test.go
@@ -548,20 +548,24 @@ func newMockStdout() *mockStdout {
 func (s *mockStdout) Write(p []byte) (n int, err error) {
 	s.buf = append(s.buf, p...)
 
-	ni := bytes.Index(p, []byte{'\n'})
+	ni := bytes.Index(s.buf, []byte{'\n'})
 	if ni < 0 {
 		return len(p), nil
 	}
 
-	buf := make([]byte, len(p))
-	copy(buf, p)
 	for ni >= 0 {
 		str := string(s.buf[:ni])
 		s.Lines <- str
 
-		s.buf = s.buf[ni+1:]
-		buf = buf[ni+1:]
-		ni = bytes.Index(buf, []byte{'\n'})
+		if len(s.buf) > ni {
+			// Try to find the next newline.
+			s.buf = s.buf[ni+1:]
+			ni = bytes.Index(s.buf, []byte{'\n'})
+		} else {
+			// The buffer is empty
+			s.buf = s.buf[0:]
+			break
+		}
 	}
 
 	return len(p), nil


### PR DESCRIPTION
There are couple of issues with the mockStdout in `main_test.go` which was triggered in the PR #256 .

- The buffer size of channel in the mockStdout is not big enough. If the logger writes more than the buffer, this'll block the logger.
- There's a possible crash in the mockStdout.

The crash log:
```
goroutine 812 [running]:
github.com/perlin-network/wavelet/cmd/wavelet.(*mockStdout).Write(0xc0002faae0, 0xc0002ae2a0, 0x57, 0x64, 0x26, 0xc0016d61b0, 0xc0000336c0)
	/Users/ahmadmuzakkir/Documents/rkeene/wavelet/cmd/wavelet/main_test.go:542 +0x3d2
github.com/benpye/readline.(*wrapWriter).Write(0xc0002a4100, 0xc0002ae2a0, 0x57, 0x64, 0x0, 0x6000107, 0x0)
	/Users/ahmadmuzakkir/go/pkg/mod/github.com/benpye/readline@v0.0.0-20181117181432-5ff4ccac79cf/operation.go:49 +0x194
bytes.(*Buffer).WriteTo(0xc00136ecc0, 0x1b5cc60, 0xc0002a4100, 0x0, 0x6, 0xc0000327c0)
	/usr/local/Cellar/go/1.12.5/libexec/src/bytes/buffer.go:242 +0xb8
github.com/perlin-network/wavelet/log.ConsoleWriter.Write(0x1b5cc60, 0xc0002a4100, 0x0, 0x19dc795, 0x6, 0xc0000327c0, 0x4, 0x4, 0x0, 0x0, ...)
	/Users/ahmadmuzakkir/Documents/rkeene/wavelet/log/console.go:173 +0x4ca
github.com/perlin-network/wavelet/log.(*multiWriter).Write(0x2288920, 0xc00148e000, 0x84, 0x1f4, 0x0, 0x0, 0x0)
	/Users/ahmadmuzakkir/Documents/rkeene/wavelet/log/io.go:44 +0x12b
github.com/rs/zerolog.levelWriterAdapter.WriteLevel(...)
	/Users/ahmadmuzakkir/go/pkg/mod/github.com/rs/zerolog@v1.14.3/writer.go:20
github.com/rs/zerolog.(*Event).write(0xc0013d63c0, 0x5b, 0x1f4)
	/Users/ahmadmuzakkir/go/pkg/mod/github.com/rs/zerolog@v1.14.3/event.go:75 +0x125
github.com/rs/zerolog.(*Event).msg(0xc0013d63c0, 0xc0016d6150, 0x26)
	/Users/ahmadmuzakkir/go/pkg/mod/github.com/rs/zerolog@v1.14.3/event.go:134 +0x13d
github.com/rs/zerolog.(*Event).Msgf(0xc0013d63c0, 0x19ecd47, 0x19, 0xc000df1f98, 0x1, 0x1)
	/Users/ahmadmuzakkir/go/pkg/mod/github.com/rs/zerolog@v1.14.3/event.go:116 +0x83
github.com/perlin-network/wavelet.(*Ledger).SyncToLatestRound.func1(0xc0001822a0, 0xc0000de380, 0xc00177e0c0, 0xc000318000, 0xc000c40380)
	/Users/ahmadmuzakkir/Documents/rkeene/wavelet/ledger.go:996 +0xe1
created by github.com/perlin-network/wavelet.(*Ledger).SyncToLatestRound
	/Users/ahmadmuzakkir/Documents/rkeene/wavelet/ledger.go:995 +0x33a

Process finished with exit code 1
```