### PR TITLE
Speed up CollapseTransactions() by buffering changes to a map.

### DIFF
--- a/cmd/wavelet/main.go
+++ b/cmd/wavelet/main.go
@@ -352,8 +352,8 @@ func start(cfg *Config, stdin io.ReadCloser, stdout io.Writer) {
 		skademlia.WithC2(sys.SKademliaC2),
 		skademlia.WithDialOptions(grpc.WithDefaultCallOptions(
 			grpc.UseCompressor(snappy.Name),
-			grpc.MaxCallRecvMsgSize(9 * 1024 * 1024),
-			grpc.MaxCallSendMsgSize(3 * 1024 * 1024),
+			grpc.MaxCallRecvMsgSize(9*1024*1024),
+			grpc.MaxCallSendMsgSize(3*1024*1024),
 		)),
 	)
 

--- a/collapse.go
+++ b/collapse.go
@@ -21,6 +21,7 @@ package wavelet
 
 import (
 	"encoding/hex"
+	"github.com/perlin-network/wavelet/lru"
 
 	"github.com/perlin-network/wavelet/avl"
 	"github.com/perlin-network/wavelet/log"
@@ -28,17 +29,6 @@ import (
 	queue2 "github.com/phf/go-queue/queue"
 	"github.com/pkg/errors"
 )
-
-func processRewardWithdrawals(round uint64, snapshot *avl.Tree) {
-	rws := GetRewardWithdrawalRequests(snapshot, round-uint64(sys.RewardWithdrawalsRoundLimit))
-
-	for _, rw := range rws {
-		balance, _ := ReadAccountBalance(snapshot, rw.account)
-		WriteAccountBalance(snapshot, rw.account, balance+rw.amount)
-
-		snapshot.Delete(rw.Key())
-	}
-}
 
 func collapseTransactions(g *Graph, accounts *Accounts, round uint64, current *Round, start, end Transaction, logging bool) (*collapseResults, error) {
 	res := &collapseResults{snapshot: accounts.Snapshot()}
@@ -82,7 +72,7 @@ func collapseTransactions(g *Graph, accounts *Accounts, round uint64, current *R
 	res.rejected = make([]*Transaction, 0, order.Len())
 	res.rejectedErrors = make([]error, 0, order.Len())
 
-	ctx := NewCollapseContext()
+	ctx := NewCollapseContext(res.snapshot)
 
 	var (
 		totalStake uint64
@@ -98,15 +88,16 @@ func collapseTransactions(g *Graph, accounts *Accounts, round uint64, current *R
 
 		// Update nonce.
 
-		nonce, exists := ReadAccountNonce(res.snapshot, popped.Creator)
+		nonce, exists := ctx.ReadAccountNonce(popped.Creator)
 		if !exists {
-			WriteAccountsLen(res.snapshot, ReadAccountsLen(res.snapshot)+1)
+			ctx.WriteAccountsLen(ctx.ReadAccountsLen() + 1)
 		}
-		WriteAccountNonce(res.snapshot, popped.Creator, nonce+1)
+		ctx.WriteAccountNonce(popped.Creator, nonce+1)
 
 		if hex.EncodeToString(popped.Creator[:]) != sys.FaucetAddress {
 			fee := popped.Fee()
-			creatorBalance, _ := ReadAccountBalance(res.snapshot, popped.Creator)
+
+			creatorBalance, _ := ctx.ReadAccountBalance(popped.Creator)
 			if creatorBalance < fee {
 				res.rejected = append(res.rejected, popped)
 				res.rejectedErrors = append(
@@ -118,11 +109,11 @@ func collapseTransactions(g *Graph, accounts *Accounts, round uint64, current *R
 				continue
 			}
 
-			WriteAccountBalance(res.snapshot, popped.Creator, creatorBalance-fee)
+			ctx.WriteAccountBalance(popped.Creator, creatorBalance-fee)
 			totalFee += fee
 
 			stake := uint64(0)
-			if s, _ := ReadAccountStake(res.snapshot, popped.Sender); s > sys.MinimumStake {
+			if s, _ := ctx.ReadAccountStake(popped.Sender); s > sys.MinimumStake {
 				stake = s
 			}
 
@@ -136,7 +127,7 @@ func collapseTransactions(g *Graph, accounts *Accounts, round uint64, current *R
 			}
 		}
 
-		if err := ApplyTransaction(current, res.snapshot, popped, ctx); err != nil {
+		if err := ctx.ApplyTransaction(current, popped); err != nil {
 			res.rejected = append(res.rejected, popped)
 			res.rejectedErrors = append(res.rejectedErrors, err)
 			res.rejectedCount += popped.LogicalUnits()
@@ -155,11 +146,10 @@ func collapseTransactions(g *Graph, accounts *Accounts, round uint64, current *R
 
 	if totalStake > 0 {
 		for sender, stake := range stakes {
-			rewardeeBalance, _ := ReadAccountReward(res.snapshot, sender)
+			rewardeeBalance, _ := ctx.ReadAccountReward(sender)
 
 			reward := float64(totalFee) * (float64(stake) / float64(totalStake))
-
-			WriteAccountReward(res.snapshot, sender, rewardeeBalance+uint64(reward))
+			ctx.WriteAccountReward(sender, rewardeeBalance+uint64(reward))
 		}
 	}
 
@@ -171,11 +161,279 @@ func collapseTransactions(g *Graph, accounts *Accounts, round uint64, current *R
 
 	res.ignoredCount -= res.appliedCount + res.rejectedCount
 
-	if round >= uint64(sys.RewardWithdrawalsRoundLimit) {
-		processRewardWithdrawals(round, res.snapshot)
+	ctx.processRewardWithdrawals(round)
+
+	if err := ctx.Flush(); err != nil {
+		return res, err
 	}
 
-	ctx.Flush(res.snapshot)
-
 	return res, nil
+}
+
+// WARNING: While using this, the tree must not be modified.
+type CollapseContext struct {
+	tree     *avl.Tree
+	checksum [16]byte
+
+	accountLen uint64
+
+	// To preserve order of state insertions of accounts
+	accountIDs []AccountID
+	accounts   map[AccountID]struct{}
+
+	writes map[AccountID]struct{}
+
+	balances            map[AccountID]uint64
+	stakes              map[AccountID]uint64
+	rewards             map[AccountID]uint64
+	nonces              map[AccountID]uint64
+	contracts           map[TransactionID][]byte
+	contractGasBalances map[TransactionID]uint64
+	contractVMs         map[AccountID]*VMState
+
+	rewardWithdrawalRequests []RewardWithdrawalRequest
+
+	VMCache *lru.LRU
+}
+
+func NewCollapseContext(tree *avl.Tree) *CollapseContext {
+	ctx := &CollapseContext{
+		tree: tree,
+	}
+
+	ctx.init()
+
+	return ctx
+}
+
+func (c *CollapseContext) init() {
+	c.checksum = c.tree.Checksum()
+
+	c.accountLen = ReadAccountsLen(c.tree)
+
+	c.accounts = make(map[AccountID]struct{})
+	c.balances = make(map[AccountID]uint64)
+	c.stakes = make(map[AccountID]uint64)
+	c.rewards = make(map[AccountID]uint64)
+	c.nonces = make(map[AccountID]uint64)
+	c.contracts = make(map[TransactionID][]byte)
+	c.contractGasBalances = make(map[TransactionID]uint64)
+	c.contractVMs = make(map[AccountID]*VMState)
+
+	c.VMCache = lru.NewLRU(4)
+}
+
+func (c *CollapseContext) ReadAccountsLen() uint64 {
+	return c.accountLen
+}
+
+func (c *CollapseContext) WriteAccountsLen(size uint64) {
+	c.accountLen = size
+}
+
+func (c *CollapseContext) ReadAccountNonce(id AccountID) (uint64, bool) {
+	if nonce, ok := c.nonces[id]; ok {
+		return nonce, true
+	}
+
+	nonce, exists := ReadAccountNonce(c.tree, id)
+	if exists {
+		c.nonces[id] = nonce
+	}
+
+	return nonce, exists
+}
+
+func (c *CollapseContext) ReadAccountBalance(id AccountID) (uint64, bool) {
+	if balance, ok := c.balances[id]; ok {
+		return balance, true
+	}
+
+	balance, exists := ReadAccountBalance(c.tree, id)
+	if exists {
+		c.balances[id] = balance
+	}
+
+	return balance, exists
+}
+
+func (c *CollapseContext) ReadAccountStake(id AccountID) (uint64, bool) {
+	if stake, ok := c.stakes[id]; ok {
+		return stake, true
+	}
+
+	stake, exists := ReadAccountStake(c.tree, id)
+	if exists {
+		c.stakes[id] = stake
+	}
+
+	return stake, exists
+}
+
+func (c *CollapseContext) ReadAccountReward(id AccountID) (uint64, bool) {
+	if reward, ok := c.rewards[id]; ok {
+		return reward, true
+	}
+
+	reward, exists := ReadAccountReward(c.tree, id)
+	if exists {
+		c.rewards[id] = reward
+	}
+
+	return reward, exists
+}
+
+func (c *CollapseContext) ReadAccountContractGasBalance(id TransactionID) (uint64, bool) {
+	if gasBalance, ok := c.contractGasBalances[id]; ok {
+		return gasBalance, true
+	}
+
+	gasBalance, exists := ReadAccountContractGasBalance(c.tree, id)
+	if exists {
+		c.contractGasBalances[id] = gasBalance
+	}
+
+	return gasBalance, exists
+}
+
+func (c *CollapseContext) ReadAccountContractCode(id TransactionID) ([]byte, bool) {
+	if code, ok := c.contracts[id]; ok {
+		return code, true
+	}
+
+	code, exists := ReadAccountContractCode(c.tree, id)
+	if exists {
+		c.contracts[id] = code
+	}
+
+	return code, exists
+}
+
+func (c *CollapseContext) GetContractState(id AccountID) (*VMState, bool) {
+	vm, exists := c.contractVMs[id]
+	return vm, exists
+}
+
+func (c *CollapseContext) addAccount(id AccountID) {
+	if _, ok := c.accounts[id]; ok {
+		return
+	}
+
+	c.accounts[id] = struct{}{}
+	c.accountIDs = append(c.accountIDs, id)
+}
+
+func (c *CollapseContext) WriteAccountNonce(id AccountID, nonce uint64) {
+	c.addAccount(id)
+	c.nonces[id] = nonce
+}
+
+func (c *CollapseContext) WriteAccountBalance(id AccountID, balance uint64) {
+	c.addAccount(id)
+	c.balances[id] = balance
+}
+
+func (c *CollapseContext) WriteAccountStake(id AccountID, stake uint64) {
+	c.addAccount(id)
+	c.stakes[id] = stake
+}
+
+func (c *CollapseContext) WriteAccountReward(id AccountID, reward uint64) {
+	c.addAccount(id)
+	c.rewards[id] = reward
+}
+
+func (c *CollapseContext) WriteAccountContractGasBalance(id TransactionID, gasBalance uint64) {
+	c.addAccount(id)
+	c.contractGasBalances[id] = gasBalance
+}
+
+func (c *CollapseContext) WriteAccountContractCode(id TransactionID, code []byte) {
+	c.addAccount(id)
+	c.contracts[id] = code
+}
+
+func (c *CollapseContext) SetContractState(id AccountID, state *VMState) {
+	c.addAccount(id)
+	c.contractVMs[id] = state
+}
+
+func (c *CollapseContext) StoreRewardWithdrawalRequest(rw RewardWithdrawalRequest) {
+	c.rewardWithdrawalRequests = append(c.rewardWithdrawalRequests, rw)
+}
+
+func (c *CollapseContext) processRewardWithdrawals(round uint64) {
+	if round < uint64(sys.RewardWithdrawalsRoundLimit) {
+		return
+	}
+
+	roundLimit := round - uint64(sys.RewardWithdrawalsRoundLimit)
+
+	var leftovers []RewardWithdrawalRequest
+
+	for i, rw := range c.rewardWithdrawalRequests {
+		if c.rewardWithdrawalRequests[i].round > roundLimit {
+			leftovers = append(leftovers, rw)
+			continue
+		}
+
+		balance, _ := c.ReadAccountBalance(rw.account)
+		c.WriteAccountBalance(rw.account, balance+rw.amount)
+	}
+
+	c.rewardWithdrawalRequests = leftovers
+}
+
+// Write the changes into the tree.
+func (c *CollapseContext) Flush() error {
+	if c.checksum != c.tree.Checksum() {
+		return errors.Errorf("stale state, the state has been modified. got merkle %x but expected %x.", c.tree.Checksum(), c.checksum)
+	}
+
+	WriteAccountsLen(c.tree, c.accountLen)
+
+	for _, id := range c.accountIDs {
+		if bal, ok := c.balances[id]; ok {
+			WriteAccountBalance(c.tree, id, bal)
+		}
+
+		if stake, ok := c.stakes[id]; ok {
+			WriteAccountStake(c.tree, id, stake)
+		}
+
+		if reward, ok := c.rewards[id]; ok {
+			WriteAccountReward(c.tree, id, reward)
+		}
+
+		if nonce, ok := c.nonces[id]; ok {
+			WriteAccountNonce(c.tree, id, nonce)
+		}
+
+		if gasBal, ok := c.contractGasBalances[id]; ok {
+			WriteAccountContractGasBalance(c.tree, id, gasBal)
+		}
+
+		if code, ok := c.contracts[id]; ok {
+			WriteAccountContractCode(c.tree, id, code)
+		}
+
+		if vm, ok := c.contractVMs[id]; ok {
+			SaveContractMemorySnapshot(c.tree, id, vm.Memory)
+			SaveContractGlobals(c.tree, id, vm.Globals)
+		}
+	}
+
+	return nil
+}
+
+// Apply a transaction by writing the states into memory.
+// After you've finished, you MUST call CollapseContext.Flush() to actually write the states into the tree.
+func (c *CollapseContext) ApplyTransaction(round *Round, tx *Transaction) error {
+	if err := applyTransaction(round, c, tx, &contractExecutorState{
+		GasPayer: tx.Creator,
+	}); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/collapse_test.go
+++ b/collapse_test.go
@@ -14,6 +14,156 @@ import (
 
 const initialBalance = 100 * 1000 * 1000 * 1000 * 1000
 
+func TestProcessRewardWithdrawals(t *testing.T) {
+	state := avl.New(store.NewInmem())
+
+	keys, err := skademlia.NewKeys(1, 1)
+	assert.NoError(t, err)
+
+	ctx := NewCollapseContext(state)
+
+	// First reward
+	ctx.StoreRewardWithdrawalRequest(RewardWithdrawalRequest{
+		account: keys.PublicKey(),
+		amount:  1,
+		round:   1,
+	})
+
+	// Second reward
+	ctx.StoreRewardWithdrawalRequest(RewardWithdrawalRequest{
+		account: keys.PublicKey(),
+		amount:  2,
+		round:   2,
+	})
+
+	// No reward is withdrew
+	ctx.processRewardWithdrawals(50)
+	assert.Len(t, ctx.rewardWithdrawalRequests, 2)
+	bal, _ := ctx.ReadAccountBalance(keys.PublicKey())
+	assert.Equal(t, uint64(0), bal)
+
+	// Withdraw only first reward
+	ctx.processRewardWithdrawals(51)
+	assert.Len(t, ctx.rewardWithdrawalRequests, 1)
+	bal, _ = ctx.ReadAccountBalance(keys.PublicKey())
+	assert.Equal(t, uint64(1), bal)
+
+	// Withdraw the second reward
+	ctx.processRewardWithdrawals(52)
+	assert.Len(t, ctx.rewardWithdrawalRequests, 0)
+	bal, _ = ctx.ReadAccountBalance(keys.PublicKey())
+	assert.Equal(t, uint64(3), bal)
+
+	assert.NoError(t, ctx.Flush())
+	bal, _ = ReadAccountBalance(state, keys.PublicKey())
+	assert.Equal(t, uint64(3), bal)
+}
+
+func TestCollapseContext(t *testing.T) {
+	state := avl.New(store.NewInmem())
+
+	ctx := NewCollapseContext(state)
+
+	// The expected account IDs and its order
+	var expectedAccountIDs []AccountID
+
+	checkAccountID := func(override bool, write func(id AccountID)) {
+		var id AccountID
+		if override {
+			// Choose a random account from the slice
+			if len(ctx.accountIDs) == 0 {
+				assert.FailNow(t, "could not choose a random account because accountIDs slice is empty")
+			}
+			id = ctx.accountIDs[rand.Intn(len(ctx.accountIDs))]
+		} else {
+			// Generate a random AccountID that does not exist
+			for {
+				_, err := rand.Read(id[:])
+				assert.NoError(t, err)
+				_, exist := ctx.accounts[id]
+				if !exist {
+					break
+				}
+			}
+
+			expectedAccountIDs = append(expectedAccountIDs, id)
+		}
+
+		write(id)
+
+		_, exist := ctx.accounts[id]
+		assert.True(t, exist)
+		// Check the account IDs and its ordering
+		assert.EqualValues(t, expectedAccountIDs, ctx.accountIDs)
+	}
+
+	// For each value, we do a write and check the value.
+	f := func(override bool) {
+
+		checkAccountID(override, func(id AccountID) {
+			ctx.WriteAccountNonce(id, 1)
+			nonce, _ := ctx.ReadAccountNonce(id)
+			assert.Equal(t, uint64(1), nonce)
+		})
+
+		checkAccountID(override, func(id AccountID) {
+			ctx.WriteAccountBalance(id, 2)
+			bal, _ := ctx.ReadAccountBalance(id)
+			assert.Equal(t, uint64(2), bal)
+		})
+
+		checkAccountID(override, func(id AccountID) {
+			ctx.WriteAccountStake(id, 3)
+			stake, _ := ctx.ReadAccountStake(id)
+			assert.Equal(t, uint64(3), stake)
+		})
+
+		checkAccountID(override, func(id AccountID) {
+			ctx.WriteAccountReward(id, 4)
+			reward, _ := ctx.ReadAccountReward(id)
+			assert.Equal(t, uint64(4), reward)
+		})
+
+		checkAccountID(override, func(id AccountID) {
+			ctx.WriteAccountContractGasBalance(id, 5)
+			gasBal, _ := ctx.ReadAccountContractGasBalance(id)
+			assert.Equal(t, uint64(5), gasBal)
+		})
+
+		checkAccountID(override, func(id AccountID) {
+			var _code [64]byte
+			_, err := rand.Read(_code[:])
+			assert.NoError(t, err)
+
+			ctx.WriteAccountContractCode(id, _code[:])
+			code, _ := ctx.ReadAccountContractCode(id)
+			assert.EqualValues(t, _code[:], code[:])
+		})
+
+		checkAccountID(override, func(id AccountID) {
+			var mem [64]byte
+			_, err := rand.Read(mem[:])
+			assert.NoError(t, err)
+
+			var globals = [2]int64{1, 2}
+
+			_vmState := &VMState{
+				Globals: globals[:],
+				Memory:  mem[:],
+			}
+			ctx.SetContractState(id, _vmState)
+			vmState, _ := ctx.GetContractState(id)
+			assert.EqualValues(t, _vmState, vmState)
+		})
+	}
+
+	// Case 1: new account IDs
+	f(false)
+
+	// Case 2: existing account IDs
+	f(true)
+}
+
 type collapseTestContainer struct {
 	graph      *Graph
 	accounts   map[AccountID]*skademlia.Keypair

--- a/contract.go
+++ b/contract.go
@@ -30,6 +30,7 @@ import (
 	"github.com/perlin-network/life/utils"
 	"github.com/perlin-network/noise/edwards25519"
 	"github.com/perlin-network/wavelet/avl"
+	"github.com/perlin-network/wavelet/lru"
 	"github.com/perlin-network/wavelet/sys"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/blake2b"
@@ -49,8 +50,7 @@ const (
 )
 
 type ContractExecutor struct {
-	ID       AccountID
-	Snapshot *avl.Tree
+	ID AccountID
 
 	Gas              uint64
 	GasLimitExceeded bool
@@ -256,15 +256,19 @@ func (e *ContractExecutor) ResolveGlobal(module, field string) int64 {
 	panic("global variables are disallowed in smart contracts")
 }
 
-// If this function returns no error and `contractState` is not nil, new state of the contract MUST be written into `contractState`.
-func (e *ContractExecutor) Execute(snapshot *avl.Tree, id AccountID, round *Round, tx *Transaction, amount, gasLimit uint64, name string, params, code []byte, ctx *CollapseContext, contractState *VMState, contractStateLoaded bool) error {
+// contractState is an optional parameter that is used to pass the VMState of the contract.
+// If you cache the VMState, you can pass it.
+// If it's nil, we'll try to load the state from the tree.
+//
+// This function MUST NOT write into the tree. The new or updated VM State must be returned.
+func (e *ContractExecutor) Execute(id AccountID, round *Round, tx *Transaction, amount, gasLimit uint64, name string, params, code []byte, tree *avl.Tree, vmCache *lru.LRU, contractState *VMState) (*VMState, error) {
 	var vm *exec.VirtualMachine
 	var err error
 
-	if cached, ok := ctx.VMCache.Load(id); ok {
+	if cached, ok := vmCache.Load(id); ok {
 		vm, err = CloneVM(cached.(*exec.VirtualMachine), e, e)
 		if err != nil {
-			return errors.Wrap(err, "cannot clone vm")
+			return nil, errors.Wrap(err, "cannot clone vm")
 		}
 		vm.Config.GasLimit = gasLimit
 	} else {
@@ -282,34 +286,34 @@ func (e *ContractExecutor) Execute(snapshot *avl.Tree, id AccountID, round *Roun
 
 		vm, err = exec.NewVirtualMachine(code, config, e, e)
 		if err != nil {
-			return errors.Wrap(err, "cannot initialize vm")
+			return nil, errors.Wrap(err, "cannot initialize vm")
 		}
 
 		cloned, err := CloneVM(vm, nil, nil)
 		if err != nil {
-			return errors.Wrap(err, "cannot clone vm")
+			return nil, errors.Wrap(err, "cannot clone vm")
 		}
 
-		ctx.VMCache.Put(id, cloned)
+		vmCache.Put(id, cloned)
 	}
 
 	// We can safely initialize the VM first before checking this because the size of the global slice
 	// is proportional to the size of the contract's global section.
 	if len(vm.Globals) > sys.ContractMaxGlobals {
-		return errors.New("too many globals")
+		return nil, errors.New("too many globals")
 	}
 
 	var firstRun bool
 
 	// If state cache is enabled and we have a valid state previously.
-	if contractState != nil && contractStateLoaded {
+	if contractState != nil {
 		vm, err = contractState.Apply(vm, e, e, true)
 		if err != nil {
-			return errors.New("unable to apply state")
+			return nil, errors.New("unable to apply state")
 		}
-	} else if mem := LoadContractMemorySnapshot(snapshot, id); mem != nil {
+	} else if mem := LoadContractMemorySnapshot(tree, id); mem != nil {
 		vm.Memory = mem
-		if globals, exists := LoadContractGlobals(snapshot, id); exists {
+		if globals, exists := LoadContractGlobals(tree, id); exists {
 			if len(globals) == len(vm.Globals) {
 				vm.Globals = globals
 			}
@@ -319,17 +323,16 @@ func (e *ContractExecutor) Execute(snapshot *avl.Tree, id AccountID, round *Roun
 	}
 
 	e.ID = id
-	e.Snapshot = snapshot
 
 	e.Payload = buildContractPayload(round, tx, amount, params)
 
 	entry, exists := vm.GetFunctionExport("_contract_" + name)
 	if !exists {
-		return errors.Wrapf(ErrContractFunctionNotFound, `fn "_contract_%s" does not exist`, name)
+		return nil, errors.Wrapf(ErrContractFunctionNotFound, `fn "_contract_%s" does not exist`, name)
 	}
 
 	if vm.FunctionCode[entry].NumParams != 0 {
-		return errors.New("entry function must not have parameters")
+		return nil, errors.New("entry function must not have parameters")
 	}
 
 	if firstRun {
@@ -367,15 +370,6 @@ func (e *ContractExecutor) Execute(snapshot *avl.Tree, id AccountID, round *Roun
 		vm.PrintStackTrace()
 	}
 
-	if vm.ExitError == nil {
-		if contractState != nil {
-			*contractState = SnapshotVMState(vm)
-		} else {
-			SaveContractMemorySnapshot(snapshot, id, vm.Memory)
-			SaveContractGlobals(snapshot, id, vm.Globals)
-		}
-	}
-
 	if vm.ExitError != nil && utils.UnifyError(vm.ExitError).Error() == "gas limit exceeded" {
 		e.Gas = gasLimit
 		e.GasLimitExceeded = true
@@ -385,10 +379,11 @@ func (e *ContractExecutor) Execute(snapshot *avl.Tree, id AccountID, round *Roun
 	}
 
 	if vm.ExitError != nil {
-		return utils.UnifyError(vm.ExitError)
-	} else {
-		return nil
+		return nil, utils.UnifyError(vm.ExitError)
 	}
+
+	vmState := SnapshotVMState(vm)
+	return &vmState, nil
 }
 
 func LoadContractGlobals(snapshot *avl.Tree, id AccountID) ([]int64, bool) {

--- a/contract_test.go
+++ b/contract_test.go
@@ -36,7 +36,7 @@ func BenchmarkContractInGraph(b *testing.B) {
 	assert.NoError(b, err)
 
 	tx := AttachSenderToTransaction(keys, NewTransaction(keys, sys.TagContract, buildContractSpawnPayload(100000, 0, code).Marshal()))
-	err = ApplyTransaction(&round, state, &tx, nil)
+	err = ApplyTransaction(state, &round, &tx)
 	assert.NoError(b, err)
 
 	contractID := AccountID(tx.ID)

--- a/tx_applier_test.go
+++ b/tx_applier_test.go
@@ -73,8 +73,6 @@ func TestApplyTransaction_Single(t *testing.T) {
 
 	round := NewRound(viewID, state.Checksum(), 0, Transaction{}, initialRoot)
 
-	ctx := NewCollapseContext()
-
 	for i := 0; i < 10000; i++ {
 		switch rng.Intn(2) {
 		case 0:
@@ -85,7 +83,7 @@ func TestApplyTransaction_Single(t *testing.T) {
 			account.effect.Balance -= amount
 
 			tx := AttachSenderToTransaction(account.keys, NewTransaction(account.keys, sys.TagStake, buildPlaceStakePayload(amount).Marshal()))
-			assert.NoError(t, ApplyTransaction(&round, state, &tx, ctx))
+			assert.NoError(t, ApplyTransaction(state, &round, &tx))
 		case 1:
 			amount := rng.Uint64()%100 + 1
 
@@ -102,13 +100,11 @@ func TestApplyTransaction_Single(t *testing.T) {
 			toAccount.effect.Balance += amount
 
 			tx := AttachSenderToTransaction(fromAccount.keys, NewTransaction(fromAccount.keys, sys.TagTransfer, buildTransferPayload(toAccountID, amount).Marshal()))
-			assert.NoError(t, ApplyTransaction(&round, state, &tx, ctx))
+			assert.NoError(t, ApplyTransaction(state, &round, &tx))
 		default:
 			panic("unreachable")
 		}
 	}
-
-	ctx.Flush(state)
 
 	for id, account := range accounts {
 		stake, _ := ReadAccountStake(state, id)
@@ -202,21 +198,19 @@ func TestApplyTransferTransaction(t *testing.T) {
 	aliceID := alice.PublicKey()
 	bobID := bob.PublicKey()
 
-	ctx := NewCollapseContext()
-
 	// Case 1 - Success
 	WriteAccountBalance(state, aliceID, 1)
 
 	tx := AttachSenderToTransaction(alice, NewTransaction(alice, sys.TagTransfer, buildTransferPayload(bobID, 1).Marshal()))
-	assert.NoError(t, ApplyTransaction(&round, state, &tx, ctx))
+	assert.NoError(t, ApplyTransaction(state, &round, &tx))
 
 	// Case 2 - Not enough balance
 	tx = AttachSenderToTransaction(alice, NewTransaction(alice, sys.TagTransfer, buildTransferPayload(bobID, 1).Marshal()))
-	assert.Error(t, ApplyTransaction(&round, state, &tx, ctx))
+	assert.Error(t, ApplyTransaction(state, &round, &tx))
 
 	// Case 3 - Self-transfer without enough balance
 	tx = AttachSenderToTransaction(alice, NewTransaction(alice, sys.TagTransfer, buildTransferPayload(aliceID, 1).Marshal()))
-	assert.Error(t, ApplyTransaction(&round, state, &tx, ctx))
+	assert.Error(t, ApplyTransaction(state, &round, &tx))
 }
 
 func TestApplyStakeTransaction(t *testing.T) {
@@ -230,23 +224,19 @@ func TestApplyStakeTransaction(t *testing.T) {
 
 	accountID := account.PublicKey()
 
-	ctx := NewCollapseContext()
-
 	// Case 1 - Placement success
 	WriteAccountBalance(state, accountID, 100)
 
 	tx := AttachSenderToTransaction(account, NewTransaction(account, sys.TagStake, buildPlaceStakePayload(100).Marshal()))
-	assert.NoError(t, ApplyTransaction(&round, state, &tx, ctx))
+	assert.NoError(t, ApplyTransaction(state, &round, &tx))
 
 	// Case 2 - Not enough balance
 	tx = AttachSenderToTransaction(account, NewTransaction(account, sys.TagStake, buildPlaceStakePayload(100).Marshal()))
-	assert.Error(t, ApplyTransaction(&round, state, &tx, ctx))
+	assert.Error(t, ApplyTransaction(state, &round, &tx))
 
 	// Case 3 - Withdrawal success
 	tx = AttachSenderToTransaction(account, NewTransaction(account, sys.TagStake, buildWithdrawStakePayload(100).Marshal()))
-	assert.NoError(t, ApplyTransaction(&round, state, &tx, ctx))
-
-	ctx.Flush(state)
+	assert.NoError(t, ApplyTransaction(state, &round, &tx))
 
 	finalBalance, _ := ReadAccountBalance(state, accountID)
 	assert.Equal(t, finalBalance, uint64(100))
@@ -266,13 +256,11 @@ func TestApplyBatchTransaction(t *testing.T) {
 	aliceID := alice.PublicKey()
 	bobID := bob.PublicKey()
 
-	ctx := NewCollapseContext()
-
 	WriteAccountBalance(state, aliceID, 100)
 
 	// initial stake
 	tx := AttachSenderToTransaction(alice, NewTransaction(alice, sys.TagStake, buildPlaceStakePayload(100).Marshal()))
-	err = ApplyTransaction(&round, state, &tx, ctx)
+	err = ApplyTransaction(state, &round, &tx)
 	assert.NoError(t, err)
 
 	// this implies order
@@ -281,9 +269,7 @@ func TestApplyBatchTransaction(t *testing.T) {
 	assert.NoError(t, batch.AddTransfer(buildTransferPayload(bobID, 100)))
 
 	tx = AttachSenderToTransaction(alice, NewTransaction(alice, sys.TagBatch, batch.Marshal()))
-	assert.NoError(t, ApplyTransaction(&round, state, &tx, ctx))
-
-	ctx.Flush(state)
+	assert.NoError(t, ApplyTransaction(state, &round, &tx))
 
 	finalBobBalance, _ := ReadAccountBalance(state, bobID)
 	assert.Equal(t, finalBobBalance, uint64(100))
@@ -298,8 +284,6 @@ func TestApplyContractTransaction(t *testing.T) {
 	account, err := skademlia.NewKeys(1, 1)
 	assert.NoError(t, err)
 
-	ctx := NewCollapseContext()
-
 	accountID := account.PublicKey()
 
 	code, err := ioutil.ReadFile("testdata/transfer_back.wasm")
@@ -308,14 +292,12 @@ func TestApplyContractTransaction(t *testing.T) {
 	// Case 1 - balance < gas_fee
 	WriteAccountBalance(state, accountID, 99999)
 	tx := AttachSenderToTransaction(account, NewTransaction(account, sys.TagContract, buildContractSpawnPayload(100000, 0, code).Marshal()))
-	assert.Error(t, ApplyTransaction(&round, state, &tx, ctx))
+	assert.Error(t, ApplyTransaction(state, &round, &tx))
 
 	// Case 2 - Success
 	WriteAccountBalance(state, accountID, 100000)
 	tx = AttachSenderToTransaction(account, NewTransaction(account, sys.TagContract, buildContractSpawnPayload(100000, 0, code).Marshal()))
-	assert.NoError(t, ApplyTransaction(&round, state, &tx, ctx))
-
-	ctx.Flush(state)
+	assert.NoError(t, ApplyTransaction(state, &round, &tx))
 
 	finalBalance, _ := ReadAccountBalance(state, accountID)
 	assert.Condition(t, func() bool { return finalBalance > 0 && finalBalance < 100000 })
@@ -326,9 +308,7 @@ func TestApplyContractTransaction(t *testing.T) {
 	WriteAccountBalance(state, accountID, 1000000000)
 	tx = AttachSenderToTransaction(account, NewTransaction(account, sys.TagTransfer, buildTransferWithInvocationPayload(contractID, 200000000, 500000, []byte("on_money_received"), nil, 0).Marshal()))
 
-	assert.NoError(t, ApplyTransaction(&round, state, &tx, ctx))
-
-	ctx.Flush(state)
+	assert.NoError(t, ApplyTransaction(state, &round, &tx))
 
 	finalBalance, _ = ReadAccountBalance(state, accountID)
 	assert.True(t, finalBalance > 1000000000-100000000-500000 && finalBalance < 1000000000-100000000)
@@ -338,9 +318,7 @@ func TestApplyContractTransaction(t *testing.T) {
 	WriteAccountContractGasBalance(state, contractID, 1000000000)
 
 	tx = AttachSenderToTransaction(account, NewTransaction(account, sys.TagTransfer, buildTransferWithInvocationPayload(contractID, 200000000, 500000, []byte("on_money_received"), nil, 0).Marshal()))
-	assert.NoError(t, ApplyTransaction(&round, state, &tx, ctx))
-
-	ctx.Flush(state)
+	assert.NoError(t, ApplyTransaction(state, &round, &tx))
 
 	finalBalance, _ = ReadAccountBalance(state, accountID)
 	assert.Equal(t, uint64(100000000), finalBalance)
@@ -352,9 +330,7 @@ func TestApplyContractTransaction(t *testing.T) {
 	WriteAccountContractGasBalance(state, contractID, 10)
 
 	tx = AttachSenderToTransaction(account, NewTransaction(account, sys.TagTransfer, buildTransferWithInvocationPayload(contractID, 200000000, 500000, []byte("on_money_received"), nil, 0).Marshal()))
-	assert.NoError(t, ApplyTransaction(&round, state, &tx, ctx))
-
-	ctx.Flush(state)
+	assert.NoError(t, ApplyTransaction(state, &round, &tx))
 
 	finalBalance, _ = ReadAccountBalance(state, accountID)
 	assert.True(t, finalBalance > 200000000-500000 && finalBalance < 200000000)
@@ -366,22 +342,20 @@ func TestApplyContractTransaction(t *testing.T) {
 	WriteAccountContractGasBalance(state, contractID, 0)
 
 	tx = AttachSenderToTransaction(account, NewTransaction(account, sys.TagTransfer, buildTransferWithInvocationPayload(contractID, 200000000, 500000, []byte("on_money_received"), nil, 0).Marshal()))
-	assert.Error(t, ApplyTransaction(&round, state, &tx, ctx))
+	assert.Error(t, ApplyTransaction(state, &round, &tx))
 
 	code, err = ioutil.ReadFile("testdata/recursive_invocation.wasm")
 	assert.NoError(t, err)
 
 	WriteAccountBalance(state, accountID, 100000000)
 	tx = AttachSenderToTransaction(account, NewTransaction(account, sys.TagContract, buildContractSpawnPayload(100000, 0, code).Marshal()))
-	assert.NoError(t, ApplyTransaction(&round, state, &tx, ctx))
+	assert.NoError(t, ApplyTransaction(state, &round, &tx))
 
 	recursiveInvocationContractID := tx.ID
 
 	WriteAccountBalance(state, accountID, 6000000)
 	tx = AttachSenderToTransaction(account, NewTransaction(account, sys.TagTransfer, buildTransferWithInvocationPayload(recursiveInvocationContractID, 0, 5000000, []byte("bomb"), recursiveInvocationContractID[:], 0).Marshal()))
-	assert.NoError(t, ApplyTransaction(&round, state, &tx, ctx))
-
-	ctx.Flush(state)
+	assert.NoError(t, ApplyTransaction(state, &round, &tx))
 
 	finalBalance, _ = ReadAccountBalance(state, accountID)
 	assert.True(t, finalBalance >= 1000000 && finalBalance < 2000000) // GasLimit specified in contract is 1000000


### PR DESCRIPTION
tx/applier, contract, collapse, cmd/wavelet: speed up collapsetransactions by having reads/writes occur in-memory vs against the avl tree