### PR TITLE
[himitsu] Refactor transactions in Mempool

### DIFF
--- a/api/mod.go
+++ b/api/mod.go
@@ -403,7 +403,7 @@ func (g *Gateway) getTransaction(ctx *fasthttp.RequestCtx) {
 	var id wavelet.TransactionID
 	copy(id[:], slice)
 
-	tx := g.ledger.Mempool().Find(id)
+	tx := g.ledger.FindTransaction(id)
 
 	if tx == nil {
 		g.renderError(ctx, ErrNotFound(errors.Errorf("could not find transaction with ID %x", id)))

--- a/cmd/wavelet/actions.go
+++ b/cmd/wavelet/actions.go
@@ -74,7 +74,7 @@ func (cli *CLI) status(ctx *cli.Context) {
 		Uint64("nonce", nonce).
 		Strs("peers", peerIDs).
 		Int("num_tx", cli.ledger.Mempool().PendingLen()).
-		Int("num_tx_in_store", cli.ledger.Mempool().Len()).
+		Int("num_tx_in_store", cli.ledger.TransactionsLen()).
 		Uint64("num_accounts_in_store", accountsLen).
 		Str("preferred_id", preferredID).
 		Str("sync_status", cli.ledger.SyncStatus()).
@@ -332,7 +332,7 @@ func (cli *CLI) find(ctx *cli.Context) {
 	var txID wavelet.TransactionID
 	copy(txID[:], buf)
 
-	tx := cli.ledger.Mempool().Find(txID)
+	tx := cli.ledger.FindTransaction(txID)
 
 	if tx != nil {
 		cli.logger.Info().

--- a/cmd/wavelet/actions.go
+++ b/cmd/wavelet/actions.go
@@ -73,7 +73,7 @@ func (cli *CLI) status(ctx *cli.Context) {
 		Uint64("reward", reward).
 		Uint64("nonce", nonce).
 		Strs("peers", peerIDs).
-		Int("num_tx", cli.ledger.Mempool().PendingLen()).
+		Int("num_tx", cli.ledger.Mempool().Len()).
 		Int("num_tx_in_store", cli.ledger.TransactionsLen()).
 		Uint64("num_accounts_in_store", accountsLen).
 		Str("preferred_id", preferredID).

--- a/ledger.go
+++ b/ledger.go
@@ -486,7 +486,7 @@ func (l *Ledger) FinalizeBlocks() {
 // next block in the chain.
 func (l *Ledger) proposeBlock() *Block {
 	proposing := make([]TransactionID, 0)
-	l.mempool.AscendPending(func(id TransactionID) bool {
+	l.mempool.Ascend(func(id TransactionID) bool {
 		proposing = append(proposing, id)
 		return true
 	})

--- a/mempool.go
+++ b/mempool.go
@@ -35,9 +35,9 @@ func NewMempool() *Mempool {
 	}
 }
 
-// PendingLen returns the number of transactions that are pending in the mempool.
+// Len returns the number of transactions that are pending in the mempool.
 // It is safe to call this function concurrently.
-func (m *Mempool) PendingLen() int {
+func (m *Mempool) Len() int {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 
@@ -130,7 +130,7 @@ func (m *Mempool) WriteTransactionIDs(w io.Writer) (int64, error) {
 
 // Ascend iterates through the mempool in ascending order.
 // It stops iterating when the iterator function returns false.
-func (m *Mempool) AscendPending(iter func(txID TransactionID) bool) {
+func (m *Mempool) Ascend(iter func(txID TransactionID) bool) {
 	m.lock.RLock()
 	m.index.Ascend(func(i btree.Item) bool {
 		return iter(i.(mempoolItem).id)
@@ -141,7 +141,7 @@ func (m *Mempool) AscendPending(iter func(txID TransactionID) bool) {
 // Ascend iterates through the mempool in ascending order, starting from
 // index 0 up to maxIndex. It stops iterating when the iterator function
 // returns false.
-func (m *Mempool) AscendPendingLessThan(maxIndex *big.Int, iter func(txID TransactionID) bool) {
+func (m *Mempool) AscendLessThan(maxIndex *big.Int, iter func(txID TransactionID) bool) {
 	m.lock.RLock()
 	m.index.AscendLessThan(mempoolItem{index: maxIndex}, func(i btree.Item) bool {
 		return iter(i.(mempoolItem).id)

--- a/mempool.go
+++ b/mempool.go
@@ -24,27 +24,15 @@ func (m mempoolItem) Less(than btree.Item) bool {
 type Mempool struct {
 	lock sync.RWMutex
 
-	// TODO: extract transactions and filter out of mempool
-	transactions map[TransactionID]*Transaction
-	index        *btree.BTree
-	filter       *bloom.BloomFilter
+	index  *btree.BTree
+	filter *bloom.BloomFilter
 }
 
 func NewMempool() *Mempool {
 	return &Mempool{
-		transactions: make(map[TransactionID]*Transaction),
-		index:        btree.New(32),
-		filter:       bloom.New(conf.GetBloomFilterM(), conf.GetBloomFilterK()),
+		index:  btree.New(32),
+		filter: bloom.New(conf.GetBloomFilterM(), conf.GetBloomFilterK()),
 	}
-}
-
-// Len returns the total number of transactions the node is aware of.
-// It is safe to call this function concurrently.
-func (m *Mempool) Len() int {
-	m.lock.RLock()
-	defer m.lock.RUnlock()
-
-	return len(m.transactions)
 }
 
 // PendingLen returns the number of transactions that are pending in the mempool.
@@ -56,29 +44,18 @@ func (m *Mempool) PendingLen() int {
 	return m.index.Len()
 }
 
-// Find attempts to search for and return a transaction by its ID in the node, or
-// otherwise returns nil.
-//
-// It is safe to call this function concurrently.
-func (m *Mempool) Find(id TransactionID) *Transaction {
-	m.lock.RLock()
-	defer m.lock.RUnlock()
-
-	return m.transactions[id]
-}
-
 // Add batch-adds a set of transactions to the mempool, and computes their indices in the mempool
 // based on the ID of the latest block the node is aware of.
-func (m *Mempool) Add(blockID BlockID, txs ...Transaction) {
+func (m *Mempool) Add(transactions *Transactions, blockID BlockID, txs ...Transaction) {
 	m.lock.Lock()
 
 	for _, tx := range txs {
-		if _, exists := m.transactions[tx.ID]; exists {
+		if transactions.Has(tx.ID) {
 			// TODO return error ?
 			continue
 		}
 
-		m.transactions[tx.ID] = &tx
+		transactions.Add(&tx)
 		m.filter.Add(tx.ID[:])
 
 		item := mempoolItem{
@@ -92,13 +69,13 @@ func (m *Mempool) Add(blockID BlockID, txs ...Transaction) {
 }
 
 // Reshuffle reshuffles the mempool for the incoming block.
-func (m *Mempool) Reshuffle(prevBlock Block, nextBlock Block) {
+func (m *Mempool) Reshuffle(transactions *Transactions, prevBlock Block, nextBlock Block) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
 	// Remove transactions contained in the next block
 	for _, id := range nextBlock.Transactions {
-		tx := m.transactions[id]
+		tx := transactions.Get(id)
 		if tx == nil {
 			continue
 		}
@@ -112,11 +89,11 @@ func (m *Mempool) Reshuffle(prevBlock Block, nextBlock Block) {
 	items := make([]mempoolItem, 0, m.index.Len())
 	m.index.Ascend(func(i btree.Item) bool {
 		item := i.(mempoolItem)
-		tx := m.transactions[item.id]
+		tx := transactions.Get(item.id)
 
 		// Prune old tx
 		if nextBlock.Index >= tx.Block+uint64(conf.GetPruningLimit()) {
-			delete(m.transactions, item.id)
+			transactions.Delete(item.id)
 			pruned++
 			return true
 		}
@@ -136,9 +113,9 @@ func (m *Mempool) Reshuffle(prevBlock Block, nextBlock Block) {
 	if pruned > 0 {
 		m.filter.ClearAll()
 
-		for id := range m.transactions {
-			m.filter.Add(id[:])
-		}
+		transactions.Iterate(func(tx *Transaction) {
+			m.filter.Add(tx.ID[:])
+		})
 	}
 }
 
@@ -158,17 +135,6 @@ func (m *Mempool) AscendPending(iter func(txID TransactionID) bool) {
 	m.index.Ascend(func(i btree.Item) bool {
 		return iter(i.(mempoolItem).id)
 	})
-	m.lock.RUnlock()
-}
-
-// Iterate through the all the transactions in non deterministic order.
-func (m *Mempool) Iter(iter func(tx Transaction) bool) {
-	m.lock.RLock()
-	for _, tx := range m.transactions {
-		if !iter(*tx) {
-			break
-		}
-	}
 	m.lock.RUnlock()
 }
 

--- a/protocol.go
+++ b/protocol.go
@@ -174,12 +174,13 @@ func (p *Protocol) PullTransactions(ctx context.Context, req *TransactionPullReq
 		return nil, err
 	}
 
-	p.ledger.mempool.Iter(func(tx Transaction) bool {
+	p.ledger.transactionsLock.RLock()
+	p.ledger.transactions.Iterate(func(tx *Transaction) {
 		if !filter.Test(tx.ID[:]) {
 			res.Transactions = append(res.Transactions, tx.Marshal())
 		}
-		return true
 	})
+	p.ledger.transactionsLock.RUnlock()
 
 	if len(res.Transactions) > 0 {
 		logger := log.Sync("pull_tx")

--- a/transactions.go
+++ b/transactions.go
@@ -1,0 +1,40 @@
+package wavelet
+
+// Transactions is NOT thread safe.
+type Transactions struct {
+	buffer map[TransactionID]*Transaction
+}
+
+func NewTransactions() *Transactions {
+	return &Transactions{
+		buffer: make(map[TransactionID]*Transaction),
+	}
+}
+
+func (t *Transactions) Add(tx *Transaction) {
+	t.buffer[tx.ID] = tx
+}
+
+// Will return nil if the transaction does not exist.
+func (t *Transactions) Get(id TransactionID) *Transaction {
+	return t.buffer[id]
+}
+
+func (t *Transactions) Has(id TransactionID) bool {
+	_, exist := t.buffer[id]
+	return exist
+}
+
+func (t *Transactions) Delete(id TransactionID) {
+	delete(t.buffer, id)
+}
+
+func (t *Transactions) Len() int {
+	return len(t.buffer)
+}
+
+func (t *Transactions) Iterate(callback func(tx *Transaction)) {
+	for _, v := range t.buffer {
+		callback(v)
+	}
+}


### PR DESCRIPTION
Currently, the ledger's transactions are stored in the `Mempool` type. This can cause confusions because the content of transactions and mempool is different. The transactions contains finalized + pending transactions while mempool contains only pending transactions

This PR creates a `Transactions` type to store the transactions and make it a field in`Ledger` instead in `Mempool`. 

This will make it more flexible. In the future if we want to change how `transactions` are stored or to implement pruning.