### PR TITLE
Improve Windows Support

### DIFF
--- a/cmd/wavelet/main.go
+++ b/cmd/wavelet/main.go
@@ -73,7 +73,7 @@ type Config struct {
 }
 
 func main() {
-	switchToUpdatedVersion()
+	switchToUpdatedVersion(true)
 
 	wavelet.SetGenesisByNetwork(sys.VersionMeta)
 

--- a/cmd/wavelet/update.go
+++ b/cmd/wavelet/update.go
@@ -218,7 +218,7 @@ func checkForUpdate(baseURL string, updateDirectory string, publicKeyPEM []byte,
 	}
 
 	/* Use the new binary */
-	switchToUpdatedVersion()
+	switchToUpdatedVersion(false)
 
 	return
 }
@@ -252,7 +252,7 @@ yQIDAQAB
 	}
 }
 
-func switchToUpdatedVersion() {
+func switchToUpdatedVersion(atStartup bool) {
 	/*
 	 * Check for the new binary
 	 */
@@ -265,7 +265,7 @@ func switchToUpdatedVersion() {
 	/*
 	 * Re-exec with the new binary
 	 */
-	switchToUpdatedBinary(binaryFileName)
+	switchToUpdatedBinary(binaryFileName, atStartup)
 
 	return
 }

--- a/cmd/wavelet/update.go
+++ b/cmd/wavelet/update.go
@@ -129,9 +129,9 @@ func downloadUpdate(baseURL string, updateDirectory string, publicKeyPEM []byte)
 	 * Download the new binary to a temporary
 	 * location while we validate the signature.
 	 */
-	binaryFileName := path.Join(updateDirectory, "wavelet" + sys.GoExe)
+	binaryFileName := path.Join(updateDirectory, "wavelet"+sys.GoExe)
 	binaryTempFileName := path.Join(updateDirectory, "wavelet.new")
-	binaryOldFileName  := path.Join(updateDirectory, "wavelet.old")
+	binaryOldFileName := path.Join(updateDirectory, "wavelet.old")
 	binaryTempFile, err := os.OpenFile(binaryTempFileName, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0600)
 	if err != nil {
 		return fmt.Errorf("Unable to create temporary file: %+v", err)
@@ -278,7 +278,7 @@ func switchToUpdatedVersion(atStartup bool) {
 	/*
 	 * Check for the new binary
 	 */
-	binaryFileName := path.Join(updateDirectory, "wavelet" + sys.GoExe)
+	binaryFileName := path.Join(updateDirectory, "wavelet"+sys.GoExe)
 	_, err := os.Stat(binaryFileName)
 	if err != nil {
 		return

--- a/cmd/wavelet/update.go
+++ b/cmd/wavelet/update.go
@@ -129,7 +129,7 @@ func downloadUpdate(baseURL string, updateDirectory string, publicKeyPEM []byte)
 	 * Download the new binary to a temporary
 	 * location while we validate the signature.
 	 */
-	binaryFileName := path.Join(updateDirectory, "wavelet")
+	binaryFileName := path.Join(updateDirectory, "wavelet" + sys.GoExe)
 	binaryTempFileName := path.Join(updateDirectory, "wavelet.new")
 	binaryOldFileName  := path.Join(updateDirectory, "wavelet.old")
 	binaryTempFile, err := os.OpenFile(binaryTempFileName, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0600)
@@ -278,7 +278,7 @@ func switchToUpdatedVersion(atStartup bool) {
 	/*
 	 * Check for the new binary
 	 */
-	binaryFileName := path.Join(updateDirectory, "wavelet")
+	binaryFileName := path.Join(updateDirectory, "wavelet" + sys.GoExe)
 	_, err := os.Stat(binaryFileName)
 	if err != nil {
 		return

--- a/cmd/wavelet/update_unix.go
+++ b/cmd/wavelet/update_unix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package main
 
 import (

--- a/cmd/wavelet/update_unix.go
+++ b/cmd/wavelet/update_unix.go
@@ -5,7 +5,7 @@ import (
 	"syscall"
 )
 
-func switchToUpdatedBinary(newBinary string) error {
+func switchToUpdatedBinary(newBinary string, atStartup bool) error {
 	origArg0 := os.Args[0]
 
 	os.Args[0] = newBinary

--- a/cmd/wavelet/update_windows.go
+++ b/cmd/wavelet/update_windows.go
@@ -1,7 +1,71 @@
 package main
 
-import "fmt"
+import "github.com/pkg/errors"
+import "os"
 
-func switchToUpdatedBinary(newBinary string) error {
-	return fmt.Errorf("Auto-updates not supported on Windows")
+func switchToUpdatedBinary(newBinary string, atStartup bool) error {
+	var attrs os.ProcAttr
+
+	/*
+	 * Windows does not provide a convienent way to replace the
+	 * process image, so we can really only switch to the new
+	 * binary before we have started doing any work as BOTH
+	 * processes will be running simultaneously.  The "atStartup"
+	 * flag indicates whether the switch has been called at start-up
+	 * prior to any goroutines/threads being created such that it
+	 * is safe to execute the child process and wait for it to exit.
+	 */
+	if !atStartup {
+		/*
+		 * XXX:TODO: It might be a safer idea to call os.Exit()
+		 * here to cause the user or service manager to restart
+		 * with the updated binary rather than letting them run
+		 * the old version with no notification
+		 */
+		return errors.New("Unable to switch to new upgraded binary except as at startup on Windows")
+	}
+
+
+	/*
+	 * Start the new child process, passing in the standard
+	 * file descriptors
+	 *
+	 * We currently do not bother to mutate os.Args[0] to
+	 * the new executable pathname since it is not examined
+	 * but we should consider it in the future
+	 */
+	attrs.Files = []*os.File{os.Stdin, os.Stdout, os.Stderr}
+	process, err := os.StartProcess(newBinary, os.Args, &attrs)
+	if err != nil {
+		return errors.Wrap(err, "Unable to execute new process during auto-update")
+	}
+
+	/*
+	 * Return value to pass along from the child process
+	 */
+	returnValue := 0
+
+	/*
+	 * Wait for the child process to terminate
+	 */
+	processStatus, err := process.Wait()
+	if err == nil {
+		if !processStatus.Success() {
+			returnValue = processStatus.ExitCode()
+		}
+	} else {
+		returnValue = 100
+	}
+
+	/*
+	 * Pass along any exit code from the child process
+	 * to our caller
+	 */
+	os.Exit(returnValue)
+
+	/*
+	 * This should never be reached as "os.Exit()" never
+	 * returns
+	 */
+	return errors.New("Internal error")
 }

--- a/cmd/wavelet/update_windows.go
+++ b/cmd/wavelet/update_windows.go
@@ -25,7 +25,6 @@ func switchToUpdatedBinary(newBinary string, atStartup bool) error {
 		return errors.New("Unable to switch to new upgraded binary except as at startup on Windows")
 	}
 
-
 	/*
 	 * Start the new child process, passing in the standard
 	 * file descriptors

--- a/recovery_unix.go
+++ b/recovery_unix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package wavelet
 
 import (

--- a/scripts/helper.sh
+++ b/scripts/helper.sh
@@ -63,7 +63,8 @@ for os_arch in $( echo ${OS_ARCH} | tr "," " " ); do
                 -X ${PROJ_DIR}/sys.GitCommit=${GIT_COMMIT} \
                 -X ${PROJ_DIR}/sys.GoVersion=${GO_VERSION} \
                 -X ${PROJ_DIR}/sys.OSArch=${os_arch} \
-                -X ${PROJ_DIR}/sys.VersionMeta=${BUILD_NETWORK}" \
+                -X ${PROJ_DIR}/sys.VersionMeta=${BUILD_NETWORK} \
+                -X ${PROJ_DIR}/sys.GoExe=${BINARY_POSTFIX}" \
             .
     )
 
@@ -76,7 +77,8 @@ for os_arch in $( echo ${OS_ARCH} | tr "," " " ); do
                 -X ${PROJ_DIR}/sys.GitCommit=${GIT_COMMIT} \
                 -X ${PROJ_DIR}/sys.GoVersion=${GO_VERSION} \
                 -X ${PROJ_DIR}/sys.OSArch=${os_arch} \
-                -X ${PROJ_DIR}/sys.VersionMeta=${BUILD_NETWORK}" \
+                -X ${PROJ_DIR}/sys.VersionMeta=${BUILD_NETWORK} \
+                -X ${PROJ_DIR}/sys.GoExe=${BINARY_POSTFIX}" \
             .
     )
 
@@ -89,7 +91,8 @@ for os_arch in $( echo ${OS_ARCH} | tr "," " " ); do
                 -X ${PROJ_DIR}/sys.GitCommit=${GIT_COMMIT} \
                 -X ${PROJ_DIR}/sys.GoVersion=${GO_VERSION} \
                 -X ${PROJ_DIR}/sys.OSArch=${os_arch} \
-                -X ${PROJ_DIR}/sys.VersionMeta=${BUILD_NETWORK}" \
+                -X ${PROJ_DIR}/sys.VersionMeta=${BUILD_NETWORK} \
+                -X ${PROJ_DIR}/sys.GoExe=${BINARY_POSTFIX}" \
             .
     )
 

--- a/sys/version.go
+++ b/sys/version.go
@@ -35,6 +35,7 @@ var (
 	GitCommit = "unset"
 	GoVersion = "unset"
 	OSArch    = "unset"
+	GoExe     = ""
 
 	// VersionMeta is append to the version string
 	VersionMeta = "testing"


### PR DESCRIPTION
This PR improves Windows support concerning two areas:

1. Fixes build-constraints so that the software actually builds on Windows;
2. Partially addresses auto-update (see comments on whether or not the process exits)