### PR TITLE
Minor fix for a panic on failed pulls

### DIFF
--- a/ledger.go
+++ b/ledger.go
@@ -433,6 +433,10 @@ func (l *Ledger) PullTransactions() {
 		for i := 0; i < cap(responses); i++ {
 			response := <-responseChan
 
+			if response == nil {
+				continue
+			}
+
 			responses = append(responses, response)
 		}
 


### PR DESCRIPTION
When client.PullTransactions() fails, nil gets subsequently dereferenced
```
5:10PM ERR failed to download missing transactions error: "rpc error: code = Unavailable desc = transport is closing" event: pull-transactions
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xa76589]

goroutine 12 [running]:
github.com/perlin-network/wavelet.(*Ledger).PullTransactions(0xc0000c4460)
        /home/rkeene/devel/perlin-dev/wavelet/ledger.go:448 +0x309
created by github.com/perlin-network/wavelet.(*Ledger).PerformConsensus
        /home/rkeene/devel/perlin-dev/wavelet/ledger.go:351 +0x3f
exit status 2
```

```
...
 416                                                 responseChan <- nil
...
 447                 for _, res := range responses {
 448                         for _, buf := range res.Transactions {
```