### PR TITLE
Have missing transaction IDs expire over time.

### DIFF
--- a/ledger.go
+++ b/ledger.go
@@ -143,7 +143,7 @@ func NewLedger(kv store.KV, client *skademlia.Client, opts ...Option) *Ledger {
 		ptr := &genesis
 
 		if _, err := blocks.Save(ptr); err != nil {
-			logger.Fatal().Err(err).Msg("BUG: blocks..Save")
+			logger.Fatal().Err(err).Msg("BUG: blocks.Save")
 		}
 
 		block = ptr
@@ -153,7 +153,10 @@ func NewLedger(kv store.KV, client *skademlia.Client, opts ...Option) *Ledger {
 
 	if block == nil {
 		logger.Fatal().Err(err).Msg("BUG: COULD NOT FIND GENESIS, OR STORAGE IS CORRUPTED.")
+		return nil
 	}
+
+	transactions := NewTransactions(block.Index)
 
 	finalizer := NewSnowball()
 	syncer := NewSnowball()
@@ -165,7 +168,7 @@ func NewLedger(kv store.KV, client *skademlia.Client, opts ...Option) *Ledger {
 
 		accounts:     accounts,
 		blocks:       blocks,
-		transactions: NewTransactions(),
+		transactions: transactions,
 
 		finalizer: finalizer,
 		syncer:    syncer,


### PR DESCRIPTION
ledger, transactions: have tx manager keep track of the latest block height, and only keep ids of missing transactions for at most PruningLimit finalized blocks