### PR TITLE
Update noise version to fix race issue in tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/minio/highwayhash v1.0.0
 	github.com/perlin-network/life v0.0.0-20190723115110-3091ed0c1be8
-	github.com/perlin-network/noise v0.0.0-20191003191839-5029dac118ac
+	github.com/perlin-network/noise v1.1.1-0.20191023080233-724c7cf9f251
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/perlin-network/life v0.0.0-20190723115110-3091ed0c1be8 h1:wFDze+PYm6o
 github.com/perlin-network/life v0.0.0-20190723115110-3091ed0c1be8/go.mod h1:z/EH0mO9zbeuTT5NX4u2VqVSG8y2vDQXz6iDKxikW2I=
 github.com/perlin-network/noise v0.0.0-20191003191839-5029dac118ac h1:u+Aim02xuIsSoB08lZnyynpmKnVtNp0WVnZnt5UOBDE=
 github.com/perlin-network/noise v0.0.0-20191003191839-5029dac118ac/go.mod h1:gtq69gqAZNXmk+lXhx7frAEbYBzPlrfaqscOoMSIFWE=
+github.com/perlin-network/noise v1.1.1-0.20191023080233-724c7cf9f251 h1:jIqtLD+n4W/E3Ztx0NJMVZN/6pELu2Qjh3r9xCcc1Rs=
+github.com/perlin-network/noise v1.1.1-0.20191023080233-724c7cf9f251/go.mod h1:gtq69gqAZNXmk+lXhx7frAEbYBzPlrfaqscOoMSIFWE=
 github.com/perlin-network/wagon v0.3.1-0.20180825141017-f8cb99b55a39 h1:CYHXy6CWxxL7ugjvCbTELOm2j5iRLEWGPl3AQYvretw=
 github.com/perlin-network/wagon v0.3.1-0.20180825141017-f8cb99b55a39/go.mod h1:zHOMvbitcZek8oshsMO5VpyBjWjV9X8cn8WTZwdebpM=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 h1:JhzVVoYvbOACxoUmOs6V/G4D5nPVUW73rKvXxP4XUJc=


### PR DESCRIPTION
This PR updates noise version in order to make tests pass on `himitsu` branch so that we can start writing tests.