### PR TITLE
Minor cleanup over transactions, and fix off-by-one error in wctl.

### DIFF
--- a/transactions.go
+++ b/transactions.go
@@ -1,6 +1,7 @@
 package wavelet
 
 import (
+	"fmt"
 	"github.com/google/btree"
 	"github.com/perlin-network/wavelet/conf"
 	"math/big"
@@ -126,9 +127,6 @@ func (t *Transactions) ReshufflePending(next Block) int {
 		tx := t.buffer[item.id]
 
 		if next.Index >= tx.Block+uint64(conf.GetPruningLimit()) {
-			delete(t.buffer, tx.ID)
-			pruned++
-
 			return true
 		}
 
@@ -137,6 +135,8 @@ func (t *Transactions) ReshufflePending(next Block) int {
 
 		return true
 	})
+
+	fmt.Printf("Restoring %d items into mempool which originally had %d items, with next block height being %d.\n", len(items), t.index.Len(), next.Index)
 
 	// Clear the entire mempool.
 

--- a/tx.go
+++ b/tx.go
@@ -53,12 +53,9 @@ func NewTransaction(sender *skademlia.Keypair, nonce, block uint64, tag sys.Tag,
 	var blockBuf [8]byte
 	binary.BigEndian.PutUint64(blockBuf[:], block)
 
-	tx := Transaction{Sender: sender.PublicKey(), Nonce: nonce, Block: block, Tag: tag, Payload: payload}
-	tx.Signature = edwards25519.Sign(sender.PrivateKey(), append(nonceBuf[:], append(blockBuf[:], append([]byte{byte(tag)}, payload...)...)...))
+	signature := edwards25519.Sign(sender.PrivateKey(), append(nonceBuf[:], append(blockBuf[:], append([]byte{byte(tag)}, payload...)...)...))
 
-	tx.ID = blake2b.Sum256(tx.Marshal())
-
-	return tx
+	return NewSignedTransaction(sender.PublicKey(), nonce, block, tag, payload, signature)
 }
 
 func NewSignedTransaction(sender edwards25519.PublicKey, nonce, block uint64, tag sys.Tag, payload []byte, signature edwards25519.Signature) Transaction {

--- a/wctl/tx.go
+++ b/wctl/tx.go
@@ -83,7 +83,7 @@ func (c *Client) SendTransaction(tag byte, payload []byte) (*TxResponse, error) 
 	var res TxResponse
 
 	nonce := atomic.AddUint64(&c.Nonce, 1)
-	block := atomic.LoadUint64(&c.Block) + 1
+	block := atomic.LoadUint64(&c.Block)
 
 	var nonceBuf [8]byte
 	binary.BigEndian.PutUint64(nonceBuf[:], nonce)
@@ -93,7 +93,7 @@ func (c *Client) SendTransaction(tag byte, payload []byte) (*TxResponse, error) 
 
 	signature := edwards25519.Sign(
 		c.PrivateKey,
-		append(nonceBuf[:], append(blockBuf[:], append([]byte{byte(tag)}, payload...)...)...),
+		append(nonceBuf[:], append(blockBuf[:], append([]byte{tag}, payload...)...)...),
 	)
 
 	req := TxRequest{


### PR DESCRIPTION
transactions: delete pruned transactions in the for loop over buffer instead of in amidst iterating over mempool index, and add debug log
wctl: make sure block height assigned to transaction is the latest block height, not the next block height
tx: simplify NewTransaction() to use NewSignedTransaction()