### PR TITLE
Log number of transactions pruned when a block is finalized.

### DIFF
--- a/cmd/wavelet/events.go
+++ b/cmd/wavelet/events.go
@@ -138,6 +138,9 @@ func onFinalized(u wctl.Finalized) {
 	logger.Info().
 		Hex("block_id", u.BlockID[:]).
 		Uint64("block_index", u.BlockHeight).
+		Int("num_applied_tx", u.NumApplied).
+		Int("num_rejected_tx", u.NumRejected).
+		Int("num_pruned_tx", u.NumPruned).
 		Msg(u.Message)
 }
 

--- a/ledger.go
+++ b/ledger.go
@@ -571,7 +571,7 @@ func (l *Ledger) finalize(block Block) {
 		return
 	}
 
-	l.transactions.ReshufflePending(block)
+	prunedCount := l.transactions.ReshufflePending(block)
 
 	_, err = l.blocks.Save(&block)
 	if err != nil {
@@ -605,6 +605,7 @@ func (l *Ledger) finalize(block Block) {
 	logger.Info().
 		Int("num_applied_tx", results.appliedCount).
 		Int("num_rejected_tx", results.rejectedCount).
+		Int("num_pruned_tx", prunedCount).
 		Uint64("old_block_height", current.Index).
 		Uint64("new_block_height", block.Index).
 		Hex("old_block_id", current.ID[:]).

--- a/transactions.go
+++ b/transactions.go
@@ -105,7 +105,7 @@ func (t *Transactions) ReshufflePending(next Block) int {
 
 	// Delete mempool entries for transactions in the finalized block.
 
-	pruned := len(next.Transactions)
+	pruned := 0
 
 	lookup := make(map[TransactionID]struct{})
 

--- a/wctl/ws_callbacks.go
+++ b/wctl/ws_callbacks.go
@@ -74,6 +74,9 @@ type (
 	Finalized struct {
 		BlockID     [32]byte `json:"block_id"`
 		BlockHeight uint64   `json:"block_index"`
+		NumApplied  int      `json:"num_applied_tx"`
+		NumRejected int      `json:"num_rejected_tx"`
+		NumPruned   int      `json:"num_pruned_tx"`
 		Message     string   `json:"message"`
 	}
 	OnFinalized = func(Finalized)

--- a/wctl/ws_consensus.go
+++ b/wctl/ws_consensus.go
@@ -67,6 +67,11 @@ func parseConsensusFinalized(c *Client, v *fastjson.Value) error {
 	}
 
 	f.BlockHeight = v.GetUint64("new_block_height")
+
+	f.NumApplied = v.GetInt("num_applied_tx")
+	f.NumRejected = v.GetInt("num_rejected_tx")
+	f.NumPruned = v.GetInt("num_pruned_tx")
+
 	f.Message = string(v.GetStringBytes("message"))
 
 	atomic.StoreUint64(&c.Block, f.BlockHeight)


### PR DESCRIPTION
events, wctl, ledger: log num transactions pruned upon finalizing a block
transactions: do not include num finalized transactions into prune count