### PR TITLE
Add num_missing_tx, and have MarkMissing be an atomic CAS operation.

### DIFF
--- a/api/msg.go
+++ b/api/msg.go
@@ -259,6 +259,8 @@ func (s *ledgerStatusResponse) marshalJSON(arena *fastjson.Arena) ([]byte, error
 		o.Set("preferred", arena.NewNull())
 	}
 
+	o.Set("num_missing_tx", arena.NewNumberInt(s.ledger.Transactions().MissingLen()))
+
 	o.Set("num_tx",
 		arena.NewNumberInt(s.ledger.Transactions().PendingLen()))
 	o.Set("num_tx_in_store",

--- a/cmd/wavelet/actions.go
+++ b/cmd/wavelet/actions.go
@@ -63,6 +63,7 @@ func (cli *CLI) status(ctx *cli.Context) {
 		Uint64("nonce", a.Nonce).
 		Strs("peers", peers).
 		Uint64("num_tx", l.NumTx).
+		Uint64("num_missing_tx", l.NumMissingTx).
 		Uint64("num_tx_in_store", l.NumTxInStore).
 		Uint64("num_accounts_in_store", l.AccountsLen).
 		Uint64("client_nonce", cli.client.Nonce).

--- a/ledger.go
+++ b/ledger.go
@@ -870,9 +870,7 @@ func (l *Ledger) query() {
 		}
 
 		for _, id := range vote.block.Transactions {
-			if !l.transactions.Has(id) {
-				l.transactions.MarkMissing(id)
-
+			if l.transactions.MarkMissing(id) {
 				vote.block = nil
 				break
 			}

--- a/transactions_test.go
+++ b/transactions_test.go
@@ -122,8 +122,9 @@ func TestTransactionsMarkMissing(t *testing.T) {
 			transactions = append(transactions, tx)
 		}
 
-		block := NewBlock(0, ZeroMerkleNodeID, ids...)
-		manager.BatchMarkMissing(block.Transactions...)
+		for _, id := range ids {
+			manager.MarkMissing(id)
+		}
 
 		// Assert the correct number of transactions are marked as missing,
 		if !assert.Len(t, manager.missing, cap(transactions)+1) || !assert.Len(t, manager.MissingIDs(), cap(transactions)+1) {
@@ -291,7 +292,9 @@ func TestTransactionsPruneOnReshuffle(t *testing.T) {
 			missingIDs = append(missingIDs, tx.ID)
 		}
 
-		manager.BatchMarkMissing(missingIDs...)
+		for _, id := range missingIDs {
+			manager.MarkMissing(id)
+		}
 
 		// Generate a unique next-block ID to shuffle with that is just 1 block index before the pruning limit.
 

--- a/wctl/ledger.go
+++ b/wctl/ledger.go
@@ -54,6 +54,7 @@ type LedgerStatusResponse struct {
 	} `json:"block"`
 
 	NumTx        uint64 `json:"num_tx"`
+	NumMissingTx uint64 `json:"num_missing_tx"`
 	NumTxInStore uint64 `json:"num_tx_in_store"`
 	AccountsLen  uint64 `json:"num_accounts_in_store"`
 
@@ -105,6 +106,7 @@ func (l *LedgerStatusResponse) UnmarshalJSON(b []byte) error {
 	}
 
 	l.NumTx = v.GetUint64("num_tx")
+	l.NumMissingTx = v.GetUint64("num_missing_tx")
 	l.NumTxInStore = v.GetUint64("num_tx_in_store")
 
 	if v.Exists("preferred") && v.Get("preferred").Type() != fastjson.TypeNull {


### PR DESCRIPTION
api, actions, wctl: add num_missing_tx to ledger status response and cli
ledger, transactions: have MarkMissing be an atomic operation that returns true if the transaction has been successfully marked missing
transactions: remove BatchMarkMissing as we do not use it