### PR TITLE
Refactor Snowball and add unit tests

### DIFF
--- a/snowball.go
+++ b/snowball.go
@@ -58,7 +58,7 @@ func (s *Snowball) Reset() {
 	s.Unlock()
 }
 
-func (s *Snowball) Tick(tallies map[VoteID]float64, votes map[VoteID]Vote) {
+func (s *Snowball) Tick(votes []Vote) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -67,11 +67,10 @@ func (s *Snowball) Tick(tallies map[VoteID]float64, votes map[VoteID]Vote) {
 	}
 
 	var majority Vote
-	var majorityTally float64 = 0
 
-	for id, tally := range tallies {
-		if tally > majorityTally {
-			majority, majorityTally = votes[id], tally
+	for _, vote := range votes {
+		if majority == nil || vote.Tally() > majority.Tally() {
+			majority = vote
 		}
 	}
 
@@ -81,7 +80,7 @@ func (s *Snowball) Tick(tallies map[VoteID]float64, votes map[VoteID]Vote) {
 		denom = 2
 	}
 
-	if majority == nil || majorityTally < conf.GetSnowballAlpha()*2/denom {
+	if majority == nil || majority.Tally() < conf.GetSnowballAlpha()*2/denom {
 		s.count = 0
 		return
 	}

--- a/snowball_test.go
+++ b/snowball_test.go
@@ -267,7 +267,8 @@ func TestSnowball(t *testing.T) {
 }
 
 // Test if all tallies have equal value and the value is lower than alpha.
-func TestSnowball_EqualTally(t *testing.T) {
+// Snowball will never decide.
+func TestSnowball_EqualTally_LowerThanAlpha(t *testing.T) {
 	t.Parallel()
 	snowballBeta := 10
 	defaultBeta := conf.GetSnowballBeta()
@@ -321,7 +322,7 @@ func TestSnowball_EqualTally(t *testing.T) {
 // This is impossible because of the way the tally calculation works, total sum of the tallies will equal to 1.
 //
 // Nevertheless, because of the way the snowball is implemented, if this happens, the snowball will prefer the first vote.
-func TestSnowball_EqualTally_Alpha(t *testing.T) {
+func TestSnowball_EqualTally_HigherThanAlpha(t *testing.T) {
 	t.Parallel()
 	snowballBeta := 10
 	defaultBeta := conf.GetSnowballBeta()

--- a/snowball_test.go
+++ b/snowball_test.go
@@ -19,167 +19,350 @@
 
 package wavelet
 
-//func TestNewSnowball(t *testing.T) {
-//	t.Parallel()
+import (
+	"encoding/binary"
+	"github.com/perlin-network/noise/edwards25519"
+	"github.com/perlin-network/noise/skademlia"
+	"github.com/perlin-network/wavelet/conf"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/blake2b"
+	"math/rand"
+	"testing"
+)
+
+type testVote struct {
+	voteID VoteID
+	voter  *skademlia.ID
+	tally  float64
+	value  interface{}
+}
+
+func newTestVote(id int, tally float64, voter *skademlia.ID, value interface{}) *testVote {
+	var voteID VoteID
+	// To avoid conflict with ZeroVoteID, make sure the id is never zero.
+	binary.BigEndian.PutUint16(voteID[:], uint16(id+1))
+
+	return &testVote{
+		voteID: voteID,
+		tally:  tally,
+		voter:  voter,
+		value:  value,
+	}
+}
+
+func (t *testVote) ID() VoteID {
+	return t.voteID
+}
+
+func (t *testVote) VoterID() AccountID {
+	return t.voter.PublicKey()
+}
+
+func (t *testVote) Length() float64 {
+	// Not applicable on this test
+	return 0
+}
+
+func (t *testVote) Value() interface{} {
+	return t.value
+}
+
+func (t *testVote) Tally() float64 {
+	return t.tally
+}
+
+func (t *testVote) SetTally(v float64) {
+	t.tally = v
+}
+
+func getRandomID(t *testing.T) *skademlia.ID {
+	pubKey := edwards25519.PublicKey{}
+	_, err := rand.Read(pubKey[:])
+	assert.NoError(t, err)
+	return skademlia.NewID("", pubKey, [blake2b.Size256]byte{})
+}
+
+func TestSnowball(t *testing.T) {
+	t.Parallel()
+	snowballBeta := 10
+	defaultBeta := conf.GetSnowballBeta()
+	conf.Update(conf.WithSnowballBeta(snowballBeta))
+	defer func() {
+		conf.Update(conf.WithSnowballBeta(defaultBeta))
+	}()
+
+	snowballK := 10
+	snowball := NewSnowball()
+
+	// Case 1: check that Snowball terminates properly given clear majority.
+
+	var value = "vote_value"
+	// A vote with clear majority.
+	majorityVoteIndex := 0
+	majorityVote := newTestVote(majorityVoteIndex, float64(snowballK), getRandomID(t), &value)
+
+	var votes []Vote
+	for i := 0; i < snowballK; i++ {
+		if i == majorityVoteIndex {
+			votes = append(votes, majorityVote)
+		} else {
+			votes = append(votes, newTestVote(i, 1, getRandomID(t), &value))
+		}
+	}
+
+	assert.Nil(t, snowball.Preferred())
+	assert.False(t, snowball.Decided())
+	assert.Zero(t, snowball.Progress())
+
+	for i := 0; i < snowballBeta+1; i++ {
+		assert.False(t, snowball.Decided())
+		snowball.Tick(votes)
+		preferred := snowball.Preferred().(*testVote)
+		assert.Equal(t, *majorityVote, *preferred)
+	}
+
+	assert.NotNil(t, snowball.Preferred())
+	assert.Equal(t, &value, snowball.Preferred().Value().(*string))
+	assert.True(t, snowball.Decided())
+	assert.Equal(t, snowballBeta+1, snowball.count)
+	assert.Len(t, snowball.counts, 1)
+
+	// Try tick once more. Does absolutely nothing.
+	cloned := *snowball
+	snowball.Tick(votes)
+	assert.Equal(t, *snowball, cloned)
+
+	// Reset Snowball and assert everything is cleared properly.
+	snowball.Reset()
+	assert.False(t, snowball.Decided())
+	assert.Nil(t, snowball.Preferred())
+	assert.Nil(t, snowball.last)
+	assert.Equal(t, 0, snowball.count)
+	assert.Len(t, snowball.counts, 0)
+
+	// Case 2: check that Snowball terminates properly given unanimous sampling of Round A, with preference
+	// first initially to check for off-by-one errors.
+
+	snowball.Prefer(majorityVote)
+
+	preferred := snowball.Preferred().(*testVote)
+	assert.Equal(t, *majorityVote, *preferred)
+
+	for i := 0; i < snowballBeta+1; i++ {
+		assert.False(t, snowball.Decided())
+		snowball.Tick(votes)
+		preferred := snowball.Preferred().(*testVote)
+		assert.Equal(t, *majorityVote, *preferred)
+	}
+
+	assert.NotNil(t, snowball.Preferred())
+	assert.Equal(t, &value, snowball.Preferred().Value().(*string))
+	assert.True(t, snowball.Decided())
+	assert.Equal(t, snowballBeta+1, snowball.count)
+	assert.Len(t, snowball.counts, 1)
+
+	// Reset Snowball and assert everything is cleared properly.
+	snowball.Reset()
+	assert.False(t, snowball.Decided())
+	assert.Nil(t, snowball.Preferred())
+	assert.Nil(t, snowball.last)
+	assert.Equal(t, 0, snowball.count)
+	assert.Len(t, snowball.counts, 0)
+
+	// Case 3: check that Snowball terminates if we sample 10 times majority vote A, then sample 11 times majority vote B.
+	// This demonstrates the that we need a large amount of samplings to overthrow our undecided preferred
+	// vote, originally being A, such that it is B.
+
+	for i := 0; i < snowballBeta; i++ {
+		assert.False(t, snowball.Decided())
+		snowball.Tick(votes)
+		preferred := snowball.Preferred().(*testVote)
+		assert.Equal(t, *majorityVote, *preferred)
+	}
+
+	assert.False(t, snowball.Decided())
+
+	// Choose a random vote for the new majority.
+	newMajorityVote := votes[5].(*testVote)
+	// Set the tally to be higher than the tally of previous majority vote.
+	newMajorityVote.SetTally(majorityVote.Tally() + 1)
+
+	for i := 0; i < snowballBeta+1; i++ {
+		assert.False(t, snowball.Decided())
+		snowball.Tick(votes)
+		preferred := snowball.Preferred().(*testVote)
+
+		if i == snowballBeta {
+			assert.Equal(t, *newMajorityVote, *preferred)
+		} else {
+			assert.Equal(t, *majorityVote, *preferred)
+
+		}
+	}
+
+	// Reset snowball and tally
+	snowball.Reset()
+	newMajorityVote.SetTally(1)
+
+	// Case 4: Check that it is impossible to overthrow decided preferred.
+
+	for i := 0; i < snowballBeta+1; i++ {
+		assert.False(t, snowball.Decided())
+		snowball.Tick(votes)
+		preferred := snowball.Preferred().(*testVote)
+		assert.Equal(t, *majorityVote, *preferred)
+	}
+
+	assert.True(t, snowball.Decided())
+
+	newMajorityVote.SetTally(majorityVote.Tally() + 1)
+	for i := 0; i < snowballBeta*2; i++ {
+		assert.True(t, snowball.Decided())
+		snowball.Tick(votes)
+		preferred := snowball.Preferred().(*testVote)
+		assert.Equal(t, *majorityVote, *preferred)
+	}
+
+	// Reset snowball and tally
+	snowball.Reset()
+	newMajorityVote.SetTally(1)
+
+	// Case 5: tick with nil slice and empty slice when the snowball has prefer. Does nothing.
+
+	snowball.Prefer(majorityVote)
+
+	assert.Equal(t, &value, snowball.Preferred().Value().(*string))
+	assert.False(t, snowball.Decided())
+	assert.Len(t, snowball.counts, 0)
+	assert.Equal(t, 0, snowball.count)
+	assert.Nil(t, snowball.last)
+
+	snowball.Tick(nil)
+	snowball.Tick([]Vote{})
+
+	assert.Equal(t, &value, snowball.Preferred().Value().(*string))
+	assert.False(t, snowball.Decided())
+	assert.Len(t, snowball.counts, 0)
+	assert.Equal(t, 0, snowball.count)
+	assert.Nil(t, snowball.last)
+
+	snowball.Reset()
+
+	// Case 6: tick with nil slice and empty slice when the snowball is empty. Does nothing.
+
+	assert.Nil(t, snowball.Preferred())
+	assert.False(t, snowball.Decided())
+	assert.Len(t, snowball.counts, 0)
+	assert.Equal(t, 0, snowball.count)
+	assert.Nil(t, snowball.last)
+
+	snowball.Tick(nil)
+	snowball.Tick([]Vote{})
+
+	assert.Nil(t, snowball.Preferred())
+	assert.False(t, snowball.Decided())
+	assert.Len(t, snowball.counts, 0)
+	assert.Equal(t, 0, snowball.count)
+	assert.Nil(t, snowball.last)
+}
+
+// Test if all tallies have equal value and the value is lower than alpha.
+func TestSnowball_EqualTally(t *testing.T) {
+	t.Parallel()
+	snowballBeta := 10
+	defaultBeta := conf.GetSnowballBeta()
+	conf.Update(conf.WithSnowballBeta(snowballBeta))
+	defer func() {
+		conf.Update(conf.WithSnowballBeta(defaultBeta))
+	}()
+
+	snowballK := 10
+	snowball := NewSnowball()
+
+	var votes []Vote
+	for i := 0; i < snowballK; i++ {
+		votes = append(votes, newTestVote(i, 0.1, getRandomID(t), nil))
+	}
+
+	// Case 1: the snowball does not have preferred.
+	// Expected: The snowball will never have preferred.
+
+	for i := 0; i < snowballBeta*2; i++ {
+		assert.False(t, snowball.Decided())
+		snowball.Tick(votes)
+
+		assert.Nil(t, snowball.Preferred())
+	}
+
+	assert.False(t, snowball.Decided())
+	assert.Nil(t, snowball.Preferred())
+
+	snowball.Reset()
+
+	// Case 1: the snowball already has preferred.
+	// Expected: The preferred will not change.
+
+	// Prefer a random vote
+	last := votes[rand.Intn(len(votes))].(*testVote)
+	snowball.Prefer(last)
+
+	for i := 0; i < snowballBeta*2; i++ {
+		assert.False(t, snowball.Decided())
+		snowball.Tick(votes)
+
+		assert.Equal(t, *last, *snowball.Preferred().(*testVote))
+	}
+
+	assert.False(t, snowball.Decided())
+	assert.Equal(t, *last, *snowball.Preferred().(*testVote))
+}
+
+// Test if all tallies have equal value and the value is higher than alpha.
+// This is impossible because of the way the tally calculation works, total sum of the tallies will equal to 1.
 //
-//	defaultBeta := conf.GetSnowballBeta()
-//	conf.Update(conf.WithSnowballBeta(10))
-//	defer func() {
-//		conf.Update(conf.WithSnowballBeta(defaultBeta))
-//	}()
-//
-//	snowball := NewSnowball()
-//
-//	keys, err := skademlia.NewKeys(1, 1)
-//	assert.NoError(t, err)
-//
-//	start := AttachSenderToTransaction(keys, NewTransaction(sys.TagTransfer, nil))
-//
-//	endA := AttachSenderToTransaction(keys, NewTransaction(sys.TagStake, nil))
-//	endB := AttachSenderToTransaction(keys, NewTransaction(sys.TagContract, nil))
-//
-//	a := NewRound(1, ZeroMerkleNodeID, 1337, start, endA)
-//	b := NewRound(1, ZeroMerkleNodeID, 1010, start, endB)
-//
-//	// Check that Snowball terminates properly given unanimous sampling of Round A.
-//
-//	assert.Nil(t, snowball.Preferred())
-//
-//	var preferred *Round
-//	for i := 0; i < 12; i++ {
-//		assert.False(t, snowball.Decided())
-//		snowball.Tick(&a)
-//		preferred = snowball.Preferred().(*Round)
-//		assert.Equal(t, *preferred, a)
-//	}
-//
-//	assert.True(t, snowball.Decided())
-//
-//	preferred = snowball.Preferred().(*Round)
-//	assert.Equal(t, *preferred, a)
-//
-//	assert.Equal(t, snowball.count, 11)
-//	assert.Len(t, snowball.counts, 1)
-//	assert.Len(t, snowball.candidates, 1)
-//
-//	// Try tick once more. Does absolutely nothing.
-//
-//	cloned := *snowball
-//	snowball.Tick(&a)
-//	assert.Equal(t, cloned, *snowball)
-//
-//	// Reset Snowball and assert everything is cleared properly.
-//
-//	snowball.Reset()
-//
-//	assert.False(t, snowball.Decided())
-//	assert.Nil(t, snowball.Preferred())
-//
-//	assert.Equal(t, snowball.count, 0)
-//	assert.Len(t, snowball.counts, 0)
-//	assert.Len(t, snowball.candidates, 0)
-//
-//	// Check that Snowball terminates properly given unanimous sampling of Round A, with preference
-//	// first initially to check for off-by-one errors.
-//
-//	snowball.Prefer(&a)
-//
-//	preferred = snowball.Preferred().(*Round)
-//	assert.Equal(t, *preferred, a)
-//
-//	for i := 0; i < 12; i++ {
-//		assert.False(t, snowball.Decided())
-//		snowball.Tick(&a)
-//		preferred = snowball.Preferred().(*Round)
-//		assert.Equal(t, *preferred, a)
-//	}
-//
-//	assert.True(t, snowball.Decided())
-//	preferred = snowball.Preferred().(*Round)
-//	assert.Equal(t, *preferred, a)
-//
-//	assert.Equal(t, snowball.count, 11)
-//	assert.Len(t, snowball.counts, 1)
-//	assert.Len(t, snowball.candidates, 1)
-//
-//	// Reset Snowball and assert everything is cleared properly.
-//
-//	snowball.Reset()
-//
-//	assert.False(t, snowball.Decided())
-//	assert.Nil(t, snowball.Preferred())
-//
-//	assert.Equal(t, snowball.count, 0)
-//	assert.Len(t, snowball.counts, 0)
-//	assert.Len(t, snowball.candidates, 0)
-//
-//	// Check that Snowball terminates if we sample 11 times Round A, then sample 12 times Round B.
-//	// This demonstrates the that we need a large amount of samplings to overthrow our preferred
-//	// round, originally being A, such that it is B.
-//
-//	for i := 0; i < 11; i++ {
-//		assert.False(t, snowball.Decided())
-//		snowball.Tick(&a)
-//		preferred = snowball.Preferred().(*Round)
-//		assert.Equal(t, *preferred, a)
-//	}
-//
-//	assert.False(t, snowball.Decided())
-//
-//	for i := 0; i < 12; i++ {
-//		assert.False(t, snowball.Decided())
-//		snowball.Tick(&b)
-//		preferred = snowball.Preferred().(*Round)
-//		if i == 11 {
-//			assert.Equal(t, *preferred, b)
-//		} else {
-//			assert.Equal(t, *preferred, a)
-//		}
-//	}
-//
-//	assert.Equal(t, snowball.counts[a.GetID()], 11)
-//	assert.Equal(t, snowball.counts[b.GetID()], 12)
-//
-//	assert.True(t, snowball.Decided())
-//
-//	preferred = snowball.Preferred().(*Round)
-//	assert.Equal(t, *preferred, b)
-//	assert.Equal(t, snowball.count, 11)
-//	assert.Len(t, snowball.counts, 2)
-//	assert.Len(t, snowball.candidates, 2)
-//
-//	// Try cause a panic by ticking with nil, or with an empty round.
-//
-//	empty := &Round{}
-//
-//	snowball.Tick(nil)
-//	snowball.Tick(empty)
-//
-//	assert.Equal(t, snowball.counts[a.GetID()], 11)
-//	assert.Equal(t, snowball.counts[b.GetID()], 12)
-//
-//	assert.True(t, snowball.Decided())
-//
-//	preferred = snowball.Preferred().(*Round)
-//	assert.Equal(t, b, *preferred)
-//	assert.Equal(t, 11, snowball.count)
-//	assert.Len(t, snowball.counts, 2)
-//	assert.Len(t, snowball.candidates, 2)
-//
-//	// Try tick with nil if Snowball has not decided yet.
-//
-//	snowball.Reset()
-//
-//	snowball.Tick(&a)
-//	snowball.Tick(&a)
-//
-//	assert.Equal(t, a.GetID(), snowball.lastID)
-//	assert.Equal(t, 1, snowball.Progress())
-//	assert.Len(t, snowball.counts, 1)
-//
-//	snowball.Tick(nil)
-//
-//	assert.Equal(t, "", snowball.lastID)
-//	assert.Equal(t, 0, snowball.Progress())
-//	assert.Len(t, snowball.counts, 1)
-//}
+// Nevertheless, because of the way the snowball is implemented, if this happens, the snowball will prefer the first vote.
+func TestSnowball_EqualTally_Alpha(t *testing.T) {
+	t.Parallel()
+	snowballBeta := 10
+	defaultBeta := conf.GetSnowballBeta()
+	conf.Update(conf.WithSnowballBeta(snowballBeta))
+	defer func() {
+		conf.Update(conf.WithSnowballBeta(defaultBeta))
+	}()
+
+	snowballK := 10
+	snowball := NewSnowball()
+
+	var votes []Vote
+	for i := 0; i < snowballK; i++ {
+		votes = append(votes, newTestVote(i, 0.2, getRandomID(t), nil))
+	}
+	firstVote := votes[0].(*testVote)
+
+	// Case 1: the snowball does not have preferred.
+	// The snowball should prefer the first vote.
+
+	for i := 0; i < snowballBeta+1; i++ {
+		assert.False(t, snowball.Decided())
+
+		snowball.Tick(votes)
+		assert.Equal(t, *firstVote, *snowball.Preferred().(*testVote))
+	}
+
+	assert.True(t, snowball.Decided())
+
+	snowball.Reset()
+
+	// Case 2: the snowball already has preferred.
+	// The snowball should prefer the first vote.
+
+	last := votes[len(votes)-1].(*testVote)
+	snowball.Prefer(last)
+
+	for i := 0; i < snowballBeta+1; i++ {
+		assert.False(t, snowball.Decided())
+		snowball.Tick(votes)
+		assert.Equal(t, *firstVote, *snowball.Preferred().(*testVote))
+	}
+	assert.True(t, snowball.Decided())
+}


### PR DESCRIPTION
Currently, snowball.Tick() has weird and redundant parameters `(tallies map[VoteID]float64, votes map[VoteID]Vote)`.

This PR refactors vote.go and snowball.go to include the tally in the `Vote`, so the snowball.Tick() has single parameter `(votes []Vote)`.

This PR also adds unit tests for `snowball.go`.