### PR TITLE
Ensure that callbacks are registered before listening

### DIFF
--- a/cmd/wavelet/node/node.go
+++ b/cmd/wavelet/node/node.go
@@ -200,6 +200,24 @@ func New(cfg *Config) (*Wavelet, error) {
 }
 
 func (w *Wavelet) Start() {
+	if w.config.APIPort == 0 {
+		w.config.APIPort = 9000
+	}
+
+	if w.config.APIHost != "" {
+		w.Gateway.StartHTTPS(
+			int(w.config.APIPort),
+			w.Net, w.Ledger, w.Keys, w.db,
+			w.config.APIHost,
+			w.config.APICertsCache, // guaranteed not empty in New
+		)
+	} else {
+		w.Gateway.StartHTTP(
+			int(w.config.APIPort),
+			w.Net, w.Ledger, w.Keys, w.db,
+		)
+	}
+
 	w.Server = w.Net.Listen()
 
 	go func() {
@@ -230,23 +248,6 @@ func (w *Wavelet) Start() {
 		w.logger.Info().Msgf("Bootstrapped with peers: %+v", ids)
 	}
 
-	if w.config.APIPort == 0 {
-		w.config.APIPort = 9000
-	}
-
-	if w.config.APIHost != "" {
-		w.Gateway.StartHTTPS(
-			int(w.config.APIPort),
-			w.Net, w.Ledger, w.Keys, w.db,
-			w.config.APIHost,
-			w.config.APICertsCache, // guaranteed not empty in New
-		)
-	} else {
-		w.Gateway.StartHTTP(
-			int(w.config.APIPort),
-			w.Net, w.Ledger, w.Keys, w.db,
-		)
-	}
 }
 
 func (w *Wavelet) Close() error {


### PR DESCRIPTION
Currently the callbacks for peers joining/leaving are set after the node starts listening for peers.  This creates a data race where `connLoop()` in Noise attempts to call those callbacks while the Wavelet node is registering them.

There is a separate PR ( https://github.com/perlin-network/noise/pull/254 ) to ensure that this does not cause a race condition, but it may be a good idea to ensure that these callbacks are registered before listening for connections.