### PR TITLE
Reduce mutex overhead in tight loop

### DIFF
--- a/ledger.go
+++ b/ledger.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
-	"github.com/willf/bloom"
 	"io"
 	"math/rand"
 	"sync"
@@ -39,6 +38,7 @@ import (
 	"github.com/perlin-network/wavelet/store"
 	"github.com/perlin-network/wavelet/sys"
 	"github.com/pkg/errors"
+	"github.com/willf/bloom"
 	"golang.org/x/crypto/blake2b"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"
@@ -867,12 +867,14 @@ func (l *Ledger) query() {
 			continue
 		}
 
+		l.transactions.Lock()
 		for _, id := range vote.block.Transactions {
 			if l.transactions.MarkMissing(id) {
 				vote.block = nil
 				break
 			}
 		}
+		l.transactions.Unlock()
 
 		if vote.block == nil {
 			continue

--- a/ledger.go
+++ b/ledger.go
@@ -856,17 +856,19 @@ func (l *Ledger) query() {
 
 	cleanupWorker()
 
-	// Filter away all query responses whose blocks comprise of transactions our node is not aware of.
 	for _, vote := range votes {
+		// Filter nil blocks
 		if vote.block == nil {
 			continue
 		}
 
+		// Filter blocks with unexpected block height
 		if vote.block.Index != current.Index+1 {
 			vote.block = nil
 			continue
 		}
 
+		// Filter blocks with at least 1 missing tx
 		l.transactions.Lock()
 		for _, id := range vote.block.Transactions {
 			if l.transactions.MarkMissing(id) {
@@ -889,6 +891,7 @@ func (l *Ledger) query() {
 			continue
 		}
 
+		// Filter blocks that results in unexpected merkle root after collapse
 		if results.snapshot.Checksum() != vote.block.Merkle {
 			vote.block = nil
 			continue

--- a/transactions.go
+++ b/transactions.go
@@ -2,10 +2,11 @@ package wavelet
 
 import (
 	"fmt"
-	"github.com/google/btree"
-	"github.com/perlin-network/wavelet/conf"
 	"math/big"
 	"sync"
+
+	"github.com/google/btree"
+	"github.com/perlin-network/wavelet/conf"
 )
 
 var _ btree.Item = (*mempoolItem)(nil)
@@ -79,9 +80,6 @@ func (t *Transactions) add(block BlockID, tx Transaction) {
 // MarkMissing marks that the node was expected to have archived a transaction with a specified id, but
 // does not have it archived and so needs to have said transaction pulled from the nodes peers.
 func (t *Transactions) MarkMissing(id TransactionID) bool {
-	t.Lock()
-	defer t.Unlock()
-
 	return t.markMissing(id)
 }
 


### PR DESCRIPTION
Profile trace:
![2019-10-25_18-13](https://user-images.githubusercontent.com/1431045/67563434-3f6d8880-f753-11e9-8e96-fe71e13488c3.png)

Mutex trace:
![2019-10-25_18-13_1](https://user-images.githubusercontent.com/1431045/67563436-41374c00-f753-11e9-9fca-0fc0516812b3.png)

With this change, `queried_bps` seems to be stable around 250 instead of steadily dropping.