### PR TITLE
Change block id to consist of transaction ids.

### DIFF
--- a/block.go
+++ b/block.go
@@ -22,11 +22,7 @@ type Block struct {
 func NewBlock(index uint64, merkle MerkleNodeID, ids ...TransactionID) Block {
 	b := Block{Index: index, Merkle: merkle, Transactions: ids}
 
-	buf := bytes.NewBuffer(nil)
-	for _, id := range ids {
-		buf.Write(id[:])
-	}
-	b.ID = blake2b.Sum256(buf.Bytes())
+	b.ID = blake2b.Sum256(b.Marshal())
 
 	return b
 }
@@ -84,12 +80,8 @@ func UnmarshalBlock(r io.Reader) (block Block, err error) {
 			return
 		}
 	}
-	
-	idBuf := bytes.NewBuffer(nil)
-	for _, id := range block.Transactions {
-		idBuf.Write(id[:])
-	}
-	block.ID = blake2b.Sum256(idBuf.Bytes())
+
+	block.ID = blake2b.Sum256(block.Marshal())
 
 	return
 }

--- a/block.go
+++ b/block.go
@@ -21,7 +21,12 @@ type Block struct {
 
 func NewBlock(index uint64, merkle MerkleNodeID, ids ...TransactionID) Block {
 	b := Block{Index: index, Merkle: merkle, Transactions: ids}
-	b.ID = blake2b.Sum256(b.Marshal())
+
+	buf := bytes.NewBuffer(nil)
+	for _, id := range ids {
+		buf.Write(id[:])
+	}
+	b.ID = blake2b.Sum256(buf.Bytes())
 
 	return b
 }
@@ -79,8 +84,12 @@ func UnmarshalBlock(r io.Reader) (block Block, err error) {
 			return
 		}
 	}
-
-	block.ID = blake2b.Sum256(block.Marshal())
+	
+	idBuf := bytes.NewBuffer(nil)
+	for _, id := range block.Transactions {
+		idBuf.Write(id[:])
+	}
+	block.ID = blake2b.Sum256(idBuf.Bytes())
 
 	return
 }

--- a/conf/conf_test.go
+++ b/conf/conf_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestGet(t *testing.T) {
 	assert.EqualValues(t, 2, GetSnowballK())
-	assert.EqualValues(t, 50, GetSnowballBeta())
+	assert.EqualValues(t, 150, GetSnowballBeta())
 
 	assert.EqualValues(t, 0.8, GetSyncVoteThreshold())
 	assert.EqualValues(t, 0.8, GetFinalizationVoteThreshold())
@@ -22,7 +22,7 @@ func TestGet(t *testing.T) {
 	assert.EqualValues(t, 5000*time.Millisecond, GetCheckOutOfSyncTimeout())
 
 	assert.EqualValues(t, 16384, GetSyncChunkSize())
-	assert.EqualValues(t, 2, GetSyncIfBlockIndicesDifferBy())
+	assert.EqualValues(t, uint64(5), GetSyncIfBlockIndicesDifferBy())
 	assert.EqualValues(t, 30, GetPruningLimit())
 	assert.EqualValues(t, "", GetSecret())
 }

--- a/ledger.go
+++ b/ledger.go
@@ -653,7 +653,6 @@ func (l *Ledger) proposeBlock() *Block {
 	}
 
 	proposed.Merkle = results.snapshot.Checksum()
-	proposed.ID = blake2b.Sum256(proposed.Marshal())
 
 	return &proposed
 }

--- a/ledger.go
+++ b/ledger.go
@@ -1377,7 +1377,13 @@ type CollapseState struct {
 // that are within the depth interval (start, end] where start is the interval starting point depth,
 // and end is the interval ending point depth.
 func (l *Ledger) collapseTransactions(block *Block, logging bool) (*collapseResults, error) {
-	_collapseState, _ := l.cacheCollapse.LoadOrPut(block.ID, &CollapseState{})
+	idBuf := bytes.NewBuffer(make([]byte, SizeTransactionID*len(block.Transactions)))
+	for _, id := range block.Transactions {
+		idBuf.Write(id[:])
+	}
+	cacheKey := blake2b.Sum256(idBuf.Bytes())
+
+	_collapseState, _ := l.cacheCollapse.LoadOrPut(cacheKey, &CollapseState{})
 	collapseState := _collapseState.(*CollapseState)
 
 	collapseState.once.Do(func() {


### PR DESCRIPTION
Since previously block id contained merkle root it changed depending on collapse result. Which led to double collapse call and wrong merkle for smart contracts.