### PR TITLE
Add wavelet tests

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Download Go modules
         run: go mod download
       - name: Run unit tests
-        run: go test -v -coverprofile=coverage.txt -covermode=atomic -race .
+        run: go test -v -coverprofile=coverage.txt -covermode=atomic -race -timeout=30m .
       - name: Upload coverage report
         uses: codecov/codecov-action@v1.0.3
         with:

--- a/ledger_test.go
+++ b/ledger_test.go
@@ -13,10 +13,6 @@ func TestLedger_Pay(t *testing.T) {
 	alice := testnet.AddNode(t)
 	bob := testnet.AddNode(t)
 
-	for i := 0; i < 5; i++ {
-		testnet.AddNode(t)
-	}
-
 	testnet.WaitForSync(t)
 
 	testnet.Faucet().Pay(alice, 1000000)
@@ -43,10 +39,6 @@ func TestLedger_PayInsufficientBalance(t *testing.T) {
 
 	alice := testnet.AddNode(t)
 	bob := testnet.AddNode(t)
-
-	for i := 0; i < 5; i++ {
-		testnet.AddNode(t)
-	}
 
 	testnet.WaitForSync(t)
 
@@ -80,10 +72,7 @@ func TestLedger_Stake(t *testing.T) {
 	defer testnet.Cleanup()
 
 	alice := testnet.AddNode(t)
-
-	for i := 0; i < 5; i++ {
-		testnet.AddNode(t)
-	}
+	testnet.AddNode(t) // bob
 
 	testnet.WaitForSync(t)
 
@@ -126,10 +115,7 @@ func TestLedger_CallContract(t *testing.T) {
 	defer testnet.Cleanup()
 
 	alice := testnet.AddNode(t)
-
-	for i := 0; i < 5; i++ {
-		testnet.AddNode(t)
-	}
+	testnet.AddNode(t) // bob
 
 	testnet.WaitForSync(t)
 
@@ -152,10 +138,7 @@ func TestLedger_DepositGas(t *testing.T) {
 	defer testnet.Cleanup()
 
 	alice := testnet.AddNode(t)
-
-	for i := 0; i < 5; i++ {
-		testnet.AddNode(t)
-	}
+	testnet.AddNode(t) // bob
 
 	testnet.WaitForSync(t)
 

--- a/ledger_test.go
+++ b/ledger_test.go
@@ -17,6 +17,8 @@ func TestLedger_Pay(t *testing.T) {
 		testnet.AddNode(t)
 	}
 
+	testnet.WaitForSync(t)
+
 	testnet.Faucet().Pay(alice, 1000000)
 	alice.WaitUntilBalance(t, 1000000)
 
@@ -45,6 +47,8 @@ func TestLedger_PayInsufficientBalance(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		testnet.AddNode(t)
 	}
+
+	testnet.WaitForSync(t)
 
 	testnet.Faucet().Pay(alice, 1000000)
 	alice.WaitUntilBalance(t, 1000000)
@@ -80,6 +84,8 @@ func TestLedger_Stake(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		testnet.AddNode(t)
 	}
+
+	testnet.WaitForSync(t)
 
 	testnet.Faucet().Pay(alice, 1000000)
 	alice.WaitUntilBalance(t, 1000000)
@@ -125,6 +131,8 @@ func TestLedger_CallContract(t *testing.T) {
 		testnet.AddNode(t)
 	}
 
+	testnet.WaitForSync(t)
+
 	testnet.Faucet().Pay(alice, 1000000)
 	alice.WaitUntilBalance(t, 1000000)
 
@@ -148,6 +156,8 @@ func TestLedger_DepositGas(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		testnet.AddNode(t)
 	}
+
+	testnet.WaitForSync(t)
 
 	testnet.Faucet().Pay(alice, 1000000)
 	alice.WaitUntilBalance(t, 1000000)

--- a/ledger_test.go
+++ b/ledger_test.go
@@ -6,45 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// func TestLedger_AddTransaction(t *testing.T) {
-// 	testnet := NewTestNetwork(t)
-// 	defer testnet.Cleanup()
-//
-// 	alice := testnet.AddNode(t) // alice
-// 	testnet.AddNode(t)          // bob
-//
-// 	start := alice.ledger.Rounds().Latest().Index
-//
-// 	assert.True(t, <-alice.WaitForSync())
-//
-// 	// Add just 1 transaction
-// 	tx, err := testnet.Faucet().PlaceStake(100)
-// 	assert.NoError(t, err)
-//
-// 	// Try to wait for 2 rounds of consensus.
-// 	// The second call should result in timeout, because
-// 	// only 1 round should be finalized.
-// 	assert.True(t, <-alice.WaitForConsensus())
-// 	assert.False(t, <-alice.WaitForConsensus())
-//
-// 	current := alice.ledger.Rounds().Latest().Index
-// 	assert.Equal(t, current-start, uint64(1), "expected only 1 round to be finalized")
-//
-// 	// Adding existing transaction returns no error as the error is ignored
-// 	assert.NoError(t, alice.ledger.AddTransaction(tx))
-//
-// 	for i := uint64(0); i < conf.GetMaxDepthDiff()+1; i++ {
-// 		assert.NoError(t, txError(testnet.Faucet().PlaceStake(1)))
-// 		alice.WaitUntilConsensus(t)
-// 	}
-//
-// 	// Force ledger to prune graph
-// 	alice.ledger.Graph().PruneBelowDepth(alice.ledger.Graph().RootDepth())
-//
-// 	// Adding a tx with depth that is too low returns no error as the error is ignored
-// 	assert.NoError(t, alice.ledger.AddTransaction(tx))
-// }
-
 func TestLedger_Pay(t *testing.T) {
 	testnet := NewTestNetwork(t)
 	defer testnet.Cleanup()
@@ -154,59 +115,53 @@ func TestLedger_Stake(t *testing.T) {
 	}
 }
 
-// func TestLedger_CallContract(t *testing.T) {
-// 	testnet := NewTestNetwork(t)
-// 	defer testnet.Cleanup()
-//
-// 	alice := testnet.AddNode(t)
-//
-// 	for i := 0; i < 5; i++ {
-// 		testnet.AddNode(t)
-// 	}
-//
-// 	testnet.WaitForSync(t)
-//
-// 	assert.NoError(t, txError(testnet.Faucet().Pay(alice, 1000000)))
-// 	alice.WaitUntilBalance(t, 1000000)
-//
-// 	contract, err := alice.SpawnContract("testdata/transfer_back.wasm",
-// 		10000, nil)
-// 	assert.NoError(t, err)
-//
-// 	alice.WaitUntilConsensus(t)
-//
-// 	// Calling the contract should cause the contract to send back 250000 PERL back to alice
-// 	_, err = alice.CallContract(contract.ID, 500000, 100000, "on_money_received", contract.ID[:])
-// 	assert.NoError(t, err)
-//
-// 	waitFor(t, func() bool { return alice.Balance() > 700000 })
-// }
-//
-// func TestLedger_DepositGas(t *testing.T) {
-// 	testnet := NewTestNetwork(t)
-// 	defer testnet.Cleanup()
-//
-// 	alice := testnet.AddNode(t)
-//
-// 	for i := 0; i < 5; i++ {
-// 		testnet.AddNode(t)
-// 	}
-//
-// 	testnet.WaitForSync(t)
-//
-// 	assert.NoError(t, txError(testnet.Faucet().Pay(alice, 1000000)))
-// 	alice.WaitUntilBalance(t, 1000000)
-//
-// 	contract, err := alice.SpawnContract("testdata/transfer_back.wasm",
-// 		10000, nil)
-// 	assert.NoError(t, err)
-//
-// 	alice.WaitUntilConsensus(t)
-//
-// 	assert.NoError(t, txError(alice.DepositGas(contract.ID, 654321)))
-// 	waitFor(t, func() bool { return alice.GasBalanceOfAddress(contract.ID) == 654321 })
-// }
-//
+func TestLedger_CallContract(t *testing.T) {
+	testnet := NewTestNetwork(t)
+	defer testnet.Cleanup()
+
+	alice := testnet.AddNode(t)
+
+	for i := 0; i < 5; i++ {
+		testnet.AddNode(t)
+	}
+
+	testnet.Faucet().Pay(alice, 1000000)
+	alice.WaitUntilBalance(t, 1000000)
+
+	contract, err := alice.SpawnContract("testdata/transfer_back.wasm",
+		10000, nil)
+	assert.NoError(t, err)
+
+	alice.WaitUntilConsensus(t)
+
+	// Calling the contract should cause the contract to send back 250000 PERL back to alice
+	alice.CallContract(contract.ID, 500000, 100000, "on_money_received", contract.ID[:])
+	waitFor(t, func() bool { return alice.Balance() > 700000 })
+}
+
+func TestLedger_DepositGas(t *testing.T) {
+	testnet := NewTestNetwork(t)
+	defer testnet.Cleanup()
+
+	alice := testnet.AddNode(t)
+
+	for i := 0; i < 5; i++ {
+		testnet.AddNode(t)
+	}
+
+	testnet.Faucet().Pay(alice, 1000000)
+	alice.WaitUntilBalance(t, 1000000)
+
+	contract, err := alice.SpawnContract("testdata/transfer_back.wasm",
+		10000, nil)
+	assert.NoError(t, err)
+
+	alice.WaitUntilConsensus(t)
+
+	alice.DepositGas(contract.ID, 654321)
+	waitFor(t, func() bool { return alice.GasBalanceOfAddress(contract.ID) == 654321 })
+}
+
 // type account struct {
 // 	PublicKey [32]byte
 // 	Balance   uint64

--- a/ledger_test.go
+++ b/ledger_test.go
@@ -1,8 +1,12 @@
 package wavelet
 
 import (
+	"bytes"
+	"math/rand"
 	"testing"
+	"time"
 
+	"github.com/perlin-network/wavelet/conf"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -155,164 +159,106 @@ func TestLedger_DepositGas(t *testing.T) {
 	waitFor(t, func() bool { return alice.GasBalanceOfAddress(contract.ID) == 654321 })
 }
 
-// type account struct {
-// 	PublicKey [32]byte
-// 	Balance   uint64
-// 	Stake     uint64
-// 	Reward    uint64
-// }
-//
-// func TestLedger_Sync(t *testing.T) {
-// 	testnet := NewTestNetwork(t)
-// 	defer testnet.Cleanup()
-//
-// 	rand.Seed(time.Now().UnixNano())
-//
-// 	var code [1024 * 1024]byte
-// 	if _, err := rand.Read(code[:]); err != nil {
-// 		t.Fatal(err)
-// 	}
-//
-// 	// Generate accounts
-// 	accounts := make([]account, 500)
-// 	for i := 0; i < len(accounts); i++ {
-// 		// Use random keys to speed up generation
-// 		var key [32]byte
-// 		if _, err := rand.Read(key[:]); err != nil {
-// 			t.Fatal(err)
-// 		}
-//
-// 		accounts[i] = account{
-// 			PublicKey: key,
-// 			Balance:   rand.Uint64(),
-// 			Stake:     rand.Uint64(),
-// 			Reward:    rand.Uint64(),
-// 		}
-// 	}
-//
-// 	// Setup network with 3 nodes
-// 	alice := testnet.Faucet()
-// 	for i := 0; i < 2; i++ {
-// 		testnet.AddNode(t)
-// 	}
-//
-// 	testnet.WaitForSync(t)
-//
-// 	// Advance the network by a few rounds larger than sys.SyncIfRoundsDifferBy
-// 	for i := 0; i < int(conf.GetSyncIfBlockIndicesDifferBy())+1; i++ {
-// 		assert.NoError(t, txError(alice.PlaceStake(1)))
-// 		alice.WaitUntilConsensus(t)
-// 	}
-//
-// 	testnet.WaitForRound(t, alice.RoundIndex())
-//
-// 	snapshot := testnet.Nodes()[0].ledger.accounts.Snapshot()
-//
-// 	snapshot.SetViewID(alice.RoundIndex() + 1)
-// 	for _, acc := range accounts {
-// 		WriteAccountBalance(snapshot, acc.PublicKey, acc.Balance)
-// 		WriteAccountStake(snapshot, acc.PublicKey, acc.Stake)
-// 		WriteAccountReward(snapshot, acc.PublicKey, acc.Reward)
-// 		WriteAccountContractCode(snapshot, acc.PublicKey, code[:])
-// 	}
-//
-// 	// Override ledger state of all nodes
-// 	for _, node := range testnet.Nodes() {
-// 		err := node.ledger.accounts.Commit(snapshot)
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-//
-// 		// Override latest round merkle with the new state snapshot
-// 		// TODO: this is causing data race
-// 		round := node.ledger.rounds.Latest()
-// 		round.Merkle = snapshot.Checksum()
-// 	}
-//
-// 	// When a new node joins the network, it will eventually
-// 	// sync with the other nodes
-// 	// log.SetWriter(log.ModuleNode, os.Stdout)
-// 	charlie := testnet.AddNode(t)
-//
-// 	timeout := time.NewTimer(time.Second * 300)
-// 	for {
-// 		select {
-// 		case <-timeout.C:
-// 			t.Fatal("timed out waiting for sync")
-//
-// 		default:
-// 			ri := <-charlie.WaitForRound(alice.RoundIndex())
-// 			if ri >= alice.RoundIndex() {
-// 				goto DONE
-// 			}
-// 		}
-// 	}
-//
-// DONE:
-// 	for _, acc := range accounts {
-// 		assert.EqualValues(t, acc.Balance, charlie.BalanceWithPublicKey(acc.PublicKey))
-// 		assert.EqualValues(t, acc.Stake, charlie.StakeWithPublicKey(acc.PublicKey))
-// 		assert.EqualValues(t, acc.Reward, charlie.RewardWithPublicKey(acc.PublicKey))
-//
-// 		checkCode, _ := ReadAccountContractCode(charlie.ledger.accounts.Snapshot(), acc.PublicKey)
-// 		assert.True(t, bytes.Equal(code[:], checkCode))
-// 	}
-// }
-//
-// func TestLedger_SpamContracts(t *testing.T) {
-// 	testnet := NewTestNetwork(t)
-// 	defer testnet.Cleanup()
-//
-// 	alice := testnet.AddNode(t)
-// 	testnet.AddNode(t)
-//
-// 	assert.True(t, <-alice.WaitForSync())
-//
-// 	assert.NoError(t, txError(testnet.Faucet().Pay(alice, 100000)))
-// 	alice.WaitUntilBalance(t, 100000)
-//
-// 	// spamming spawn transactions should cause no problem for consensus
-// 	// this is possible if they applied in different order on different nodes
-// 	for i := 0; i < 5; i++ {
-// 		_, err := alice.SpawnContract("testdata/transfer_back.wasm", 10000, nil)
-// 		if !assert.NoError(t, err) {
-// 			return
-// 		}
-// 	}
-//
-// 	alice.WaitUntilConsensus(t)
-// }
-//
-// func TestLedger_MinimalSync(t *testing.T) {
-// 	testnet := NewTestNetwork(t, WithoutFaucet())
-// 	defer testnet.Cleanup()
-//
-// 	var alice, bob *TestLedger
-// 	for i := 0; i < 4; i++ {
-// 		switch i {
-// 		case 0:
-// 			alice = testnet.AddNode(t,
-// 				WithWallet(FaucetWallet))
-// 			testnet.SetFaucet(alice)
-//
-// 		case 1:
-// 			bob = testnet.AddNode(t)
-//
-// 		default:
-// 			testnet.AddNode(t)
-// 		}
-// 	}
-//
-// 	assert.NoError(t, txError(alice.Pay(bob, 100)))
-// 	bob.WaitUntilBalance(t, 100)
-//
-// 	// End of round 1
-//
-// 	charlie := testnet.AddNode(t)
-// 	<-charlie.WaitForSync()
-//
-// 	assert.NoError(t, txError(alice.Pay(bob, 100)))
-//
-// 	bob.WaitUntilBalance(t, 200)
-// 	charlie.WaitUntilRound(t, 2)
-// }
+type account struct {
+	PublicKey [32]byte
+	Balance   uint64
+	Stake     uint64
+	Reward    uint64
+}
+
+func TestLedger_Sync(t *testing.T) {
+	testnet := NewTestNetwork(t)
+	defer testnet.Cleanup()
+
+	rand.Seed(time.Now().UnixNano())
+
+	var code [1024 * 1024]byte
+	if _, err := rand.Read(code[:]); err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate accounts
+	accounts := make([]account, 100)
+	for i := 0; i < len(accounts); i++ {
+		// Use random keys to speed up generation
+		var key [32]byte
+		if _, err := rand.Read(key[:]); err != nil {
+			t.Fatal(err)
+		}
+
+		accounts[i] = account{
+			PublicKey: key,
+			Balance:   rand.Uint64(),
+			Stake:     rand.Uint64(),
+			Reward:    rand.Uint64(),
+		}
+	}
+
+	// Setup network with 3 nodes
+	alice := testnet.Faucet()
+	for i := 0; i < 2; i++ {
+		testnet.AddNode(t)
+	}
+
+	testnet.WaitUntilSync(t)
+
+	// Advance the network by a few blocks larger than sys.SyncIfBlockIndicesDifferBy
+	for i := 0; i < int(conf.GetSyncIfBlockIndicesDifferBy())+1; i++ {
+		alice.PlaceStake(1)
+		alice.WaitUntilConsensus(t)
+	}
+
+	testnet.WaitForBlock(t, alice.BlockIndex())
+
+	snapshot := testnet.Nodes()[0].ledger.accounts.Snapshot()
+
+	snapshot.SetViewID(alice.BlockIndex() + 1)
+	for _, acc := range accounts {
+		WriteAccountBalance(snapshot, acc.PublicKey, acc.Balance)
+		WriteAccountStake(snapshot, acc.PublicKey, acc.Stake)
+		WriteAccountReward(snapshot, acc.PublicKey, acc.Reward)
+		WriteAccountContractCode(snapshot, acc.PublicKey, code[:])
+	}
+
+	// Override ledger state of all nodes
+	for _, node := range testnet.Nodes() {
+		err := node.ledger.accounts.Commit(snapshot)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Override latest round merkle with the new state snapshot
+		// TODO: this is causing data race
+		block := node.ledger.blocks.Latest()
+		block.Merkle = snapshot.Checksum()
+	}
+
+	// When a new node joins the network, it will eventually
+	// sync with the other nodes
+	// log.SetWriter(log.ModuleNode, os.Stdout)
+	charlie := testnet.AddNode(t)
+
+	timeout := time.NewTimer(time.Second * 1000)
+	for {
+		select {
+		case <-timeout.C:
+			t.Fatal("timed out waiting for sync")
+
+		default:
+			ri := <-charlie.WaitForBlock(alice.BlockIndex())
+			if ri >= alice.BlockIndex() {
+				goto DONE
+			}
+		}
+	}
+
+DONE:
+	for _, acc := range accounts {
+		assert.EqualValues(t, acc.Balance, charlie.BalanceWithPublicKey(acc.PublicKey))
+		assert.EqualValues(t, acc.Stake, charlie.StakeWithPublicKey(acc.PublicKey))
+		assert.EqualValues(t, acc.Reward, charlie.RewardWithPublicKey(acc.PublicKey))
+
+		checkCode, _ := ReadAccountContractCode(charlie.ledger.accounts.Snapshot(), acc.PublicKey)
+		assert.True(t, bytes.Equal(code[:], checkCode))
+	}
+}

--- a/ledger_test.go
+++ b/ledger_test.go
@@ -13,7 +13,7 @@ func TestLedger_Pay(t *testing.T) {
 	alice := testnet.AddNode(t)
 	bob := testnet.AddNode(t)
 
-	testnet.WaitForSync(t)
+	testnet.WaitUntilSync(t)
 
 	testnet.Faucet().Pay(alice, 1000000)
 	alice.WaitUntilBalance(t, 1000000)
@@ -40,7 +40,7 @@ func TestLedger_PayInsufficientBalance(t *testing.T) {
 	alice := testnet.AddNode(t)
 	bob := testnet.AddNode(t)
 
-	testnet.WaitForSync(t)
+	testnet.WaitUntilSync(t)
 
 	testnet.Faucet().Pay(alice, 1000000)
 	alice.WaitUntilBalance(t, 1000000)
@@ -74,7 +74,7 @@ func TestLedger_Stake(t *testing.T) {
 	alice := testnet.AddNode(t)
 	testnet.AddNode(t) // bob
 
-	testnet.WaitForSync(t)
+	testnet.WaitUntilSync(t)
 
 	testnet.Faucet().Pay(alice, 1000000)
 	alice.WaitUntilBalance(t, 1000000)
@@ -117,7 +117,7 @@ func TestLedger_CallContract(t *testing.T) {
 	alice := testnet.AddNode(t)
 	testnet.AddNode(t) // bob
 
-	testnet.WaitForSync(t)
+	testnet.WaitUntilSync(t)
 
 	testnet.Faucet().Pay(alice, 1000000)
 	alice.WaitUntilBalance(t, 1000000)
@@ -140,7 +140,7 @@ func TestLedger_DepositGas(t *testing.T) {
 	alice := testnet.AddNode(t)
 	testnet.AddNode(t) // bob
 
-	testnet.WaitForSync(t)
+	testnet.WaitUntilSync(t)
 
 	testnet.Faucet().Pay(alice, 1000000)
 	alice.WaitUntilBalance(t, 1000000)

--- a/ledger_test.go
+++ b/ledger_test.go
@@ -110,53 +110,50 @@ func TestLedger_PayInsufficientBalance(t *testing.T) {
 	}
 }
 
-//
-// func TestLedger_Stake(t *testing.T) {
-// 	testnet := NewTestNetwork(t)
-// 	defer testnet.Cleanup()
-//
-// 	alice := testnet.AddNode(t)
-//
-// 	for i := 0; i < 5; i++ {
-// 		testnet.AddNode(t)
-// 	}
-//
-// 	testnet.WaitForSync(t)
-//
-// 	assert.NoError(t, txError(testnet.Faucet().Pay(alice, 1000000)))
-// 	alice.WaitUntilBalance(t, 1000000)
-//
-// 	assert.NoError(t, txError(alice.PlaceStake(9001)))
-// 	alice.WaitUntilStake(t, 9001)
-//
-// 	// Alice balance should be balance-stakeAmount-gas
-// 	waitFor(t, func() bool { return alice.Balance() < 1000000-9001 })
-//
-// 	// Everyone else should see the updated balance of Alice
-// 	for _, node := range testnet.Nodes() {
-// 		waitFor(t, func() bool {
-// 			return node.BalanceOfAccount(alice) == alice.Balance() &&
-// 				node.StakeOfAccount(alice) == alice.Stake()
-// 		})
-// 	}
-//
-// 	oldBalance := alice.Balance()
-//
-// 	assert.NoError(t, txError(alice.WithdrawStake(5000)))
-// 	alice.WaitUntilStake(t, 4001)
-//
-// 	// Withdrawn stake should be added to balance
-// 	waitFor(t, func() bool { return alice.Balance() > oldBalance })
-//
-// 	// Everyone else should see the updated balance of Alice
-// 	for _, node := range testnet.Nodes() {
-// 		waitFor(t, func() bool {
-// 			return node.BalanceOfAccount(alice) == alice.Balance() &&
-// 				node.StakeOfAccount(alice) == alice.Stake()
-// 		})
-// 	}
-// }
-//
+func TestLedger_Stake(t *testing.T) {
+	testnet := NewTestNetwork(t)
+	defer testnet.Cleanup()
+
+	alice := testnet.AddNode(t)
+
+	for i := 0; i < 5; i++ {
+		testnet.AddNode(t)
+	}
+
+	testnet.Faucet().Pay(alice, 1000000)
+	alice.WaitUntilBalance(t, 1000000)
+
+	alice.PlaceStake(9001)
+	alice.WaitUntilStake(t, 9001)
+
+	// Alice balance should be balance-stakeAmount-gas
+	waitFor(t, func() bool { return alice.Balance() < 1000000-9001 })
+
+	// Everyone else should see the updated balance of Alice
+	for _, node := range testnet.Nodes() {
+		waitFor(t, func() bool {
+			return node.BalanceOfAccount(alice) == alice.Balance() &&
+				node.StakeOfAccount(alice) == alice.Stake()
+		})
+	}
+
+	oldBalance := alice.Balance()
+
+	alice.WithdrawStake(5000)
+	alice.WaitUntilStake(t, 4001)
+
+	// Withdrawn stake should be added to balance
+	waitFor(t, func() bool { return alice.Balance() > oldBalance })
+
+	// Everyone else should see the updated balance of Alice
+	for _, node := range testnet.Nodes() {
+		waitFor(t, func() bool {
+			return node.BalanceOfAccount(alice) == alice.Balance() &&
+				node.StakeOfAccount(alice) == alice.Stake()
+		})
+	}
+}
+
 // func TestLedger_CallContract(t *testing.T) {
 // 	testnet := NewTestNetwork(t)
 // 	defer testnet.Cleanup()

--- a/ledger_test.go
+++ b/ledger_test.go
@@ -1,464 +1,373 @@
 package wavelet
 
-//import (
-//	"bytes"
-//	"math/rand"
-//	"sync"
-//	"testing"
-//	"time"
-//
-//	"github.com/perlin-network/wavelet/conf"
-//	"github.com/stretchr/testify/assert"
-//)
-//
-//// TestLedger_BroadcastNop checks that:
-////
-//// * The ledger will keep broadcasting nop tx as long
-////   as there are unapplied tx (latestTxDepth <= rootDepth).
-////
-//// * The ledger will stop broadcasting nop once there
-////   are no more unapplied tx.
-//func TestLedger_BroadcastNop(t *testing.T) {
-//	testnet := NewTestNetwork(t)
-//	defer testnet.Cleanup()
-//
-//	alice := testnet.AddNode(t)
-//	bob := testnet.AddNode(t)
-//
-//	assert.True(t, <-alice.WaitForSync())
-//	assert.True(t, <-bob.WaitForSync())
-//
-//	assert.NoError(t, txError(testnet.Faucet().Pay(alice, 1000000)))
-//	alice.WaitUntilBalance(t, 1000000)
-//
-//	// Add lots of transactions
-//	var txsLock sync.Mutex
-//	txs := make([]Transaction, 0, 10000)
-//
-//	go func() {
-//		for i := 0; i < cap(txs); i++ {
-//			tx, err := alice.Pay(bob, 1)
-//			assert.NoError(t, err)
-//
-//			txsLock.Lock()
-//			txs = append(txs, tx)
-//			txsLock.Unlock()
-//
-//			// Somehow this prevents AddTransaction from
-//			// returning ErrMissingParents
-//			time.Sleep(time.Nanosecond * 1)
-//		}
-//	}()
-//
-//	prevRound := alice.ledger.Rounds().Latest().Index
-//	timeout := time.NewTimer(time.Minute * 5)
-//	for {
-//		select {
-//		case <-timeout.C:
-//			t.Fatal("timed out before all transactions are applied")
-//
-//		case <-alice.WaitForConsensus():
-//			var appliedCount int
-//			var txsCount int
-//
-//			txsLock.Lock()
-//			for _, tx := range txs {
-//				if alice.Applied(tx) {
-//					appliedCount++
-//				}
-//				txsCount++
-//			}
-//			txsLock.Unlock()
-//
-//			currRound := alice.ledger.Rounds().Latest().Index
-//
-//			if currRound-prevRound > 1 {
-//				t.Fatal("more than 1 round finalized")
-//			}
-//
-//			prevRound = currRound
-//
-//			if appliedCount < cap(txs) {
-//				assert.True(t, alice.ledger.BroadcastingNop(),
-//					"node should not stop broadcasting nop while there are unapplied tx")
-//			}
-//
-//			// The test is successful if all tx are applied,
-//			// and nop broadcasting is stopped once all tx are applied
-//			if appliedCount == cap(txs) && !alice.ledger.BroadcastingNop() {
-//				return
-//			}
-//		}
-//	}
-//}
-//
-//func TestLedger_AddTransaction(t *testing.T) {
-//	testnet := NewTestNetwork(t)
-//	defer testnet.Cleanup()
-//
-//	alice := testnet.AddNode(t) // alice
-//	testnet.AddNode(t)          // bob
-//
-//	start := alice.ledger.Rounds().Latest().Index
-//
-//	assert.True(t, <-alice.WaitForSync())
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// func TestLedger_AddTransaction(t *testing.T) {
+// 	testnet := NewTestNetwork(t)
+// 	defer testnet.Cleanup()
+//
+// 	alice := testnet.AddNode(t) // alice
+// 	testnet.AddNode(t)          // bob
+//
+// 	start := alice.ledger.Rounds().Latest().Index
+//
+// 	assert.True(t, <-alice.WaitForSync())
+//
+// 	// Add just 1 transaction
+// 	tx, err := testnet.Faucet().PlaceStake(100)
+// 	assert.NoError(t, err)
+//
+// 	// Try to wait for 2 rounds of consensus.
+// 	// The second call should result in timeout, because
+// 	// only 1 round should be finalized.
+// 	assert.True(t, <-alice.WaitForConsensus())
+// 	assert.False(t, <-alice.WaitForConsensus())
+//
+// 	current := alice.ledger.Rounds().Latest().Index
+// 	assert.Equal(t, current-start, uint64(1), "expected only 1 round to be finalized")
+//
+// 	// Adding existing transaction returns no error as the error is ignored
+// 	assert.NoError(t, alice.ledger.AddTransaction(tx))
+//
+// 	for i := uint64(0); i < conf.GetMaxDepthDiff()+1; i++ {
+// 		assert.NoError(t, txError(testnet.Faucet().PlaceStake(1)))
+// 		alice.WaitUntilConsensus(t)
+// 	}
+//
+// 	// Force ledger to prune graph
+// 	alice.ledger.Graph().PruneBelowDepth(alice.ledger.Graph().RootDepth())
+//
+// 	// Adding a tx with depth that is too low returns no error as the error is ignored
+// 	assert.NoError(t, alice.ledger.AddTransaction(tx))
+// }
+
+func TestLedger_Pay(t *testing.T) {
+	testnet := NewTestNetwork(t)
+	defer testnet.Cleanup()
+
+	alice := testnet.AddNode(t)
+	bob := testnet.AddNode(t)
+
+	for i := 0; i < 5; i++ {
+		testnet.AddNode(t)
+	}
+
+	testnet.Faucet().Pay(alice, 1000000)
+	alice.WaitUntilBalance(t, 1000000)
+
+	alice.Pay(bob, 1337)
+	bob.WaitUntilBalance(t, 1337)
+
+	// Alice balance should be balance-txAmount-gas
+	waitFor(t, func() bool { return alice.Balance() < 1000000-1337 })
+
+	// Everyone else should see the updated balance of Alice and Bob
+	for _, node := range testnet.Nodes() {
+		waitFor(t, func() bool {
+			return node.BalanceOfAccount(alice) == alice.Balance() &&
+				node.BalanceOfAccount(bob) == 1337
+		})
+	}
+}
+
+func TestLedger_PayInsufficientBalance(t *testing.T) {
+	testnet := NewTestNetwork(t)
+	defer testnet.Cleanup()
+
+	alice := testnet.AddNode(t)
+	bob := testnet.AddNode(t)
+
+	for i := 0; i < 5; i++ {
+		testnet.AddNode(t)
+	}
+
+	testnet.Faucet().Pay(alice, 1000000)
+	alice.WaitUntilBalance(t, 1000000)
+
+	// Alice attempt to pay Bob more than what
+	// she has in her wallet
+	alice.Pay(bob, 1000001)
+	alice.WaitUntilConsensus(t)
+
+	// Alice should have paid for gas even though the tx failed
+	waitFor(t, func() bool {
+		return alice.Balance() > 0 && alice.Balance() < 1000000
+	})
+
+	// Bob should not receive the tx amount
+	assert.EqualValues(t, 0, bob.Balance())
+
+	// Everyone else should see the updated balance of Alice and Bob
+	for _, node := range testnet.Nodes() {
+		waitFor(t, func() bool {
+			return node.BalanceOfAccount(alice) == alice.Balance() &&
+				node.BalanceOfAccount(bob) == 0
+		})
+	}
+}
+
 //
-//	// Add just 1 transaction
-//	tx, err := testnet.Faucet().PlaceStake(100)
-//	assert.NoError(t, err)
+// func TestLedger_Stake(t *testing.T) {
+// 	testnet := NewTestNetwork(t)
+// 	defer testnet.Cleanup()
 //
-//	// Try to wait for 2 rounds of consensus.
-//	// The second call should result in timeout, because
-//	// only 1 round should be finalized.
-//	assert.True(t, <-alice.WaitForConsensus())
-//	assert.False(t, <-alice.WaitForConsensus())
+// 	alice := testnet.AddNode(t)
 //
-//	current := alice.ledger.Rounds().Latest().Index
-//	assert.Equal(t, current-start, uint64(1), "expected only 1 round to be finalized")
+// 	for i := 0; i < 5; i++ {
+// 		testnet.AddNode(t)
+// 	}
 //
-//	// Adding existing transaction returns no error as the error is ignored
-//	assert.NoError(t, alice.ledger.AddTransaction(tx))
+// 	testnet.WaitForSync(t)
 //
-//	for i := uint64(0); i < conf.GetMaxDepthDiff()+1; i++ {
-//		assert.NoError(t, txError(testnet.Faucet().PlaceStake(1)))
-//		alice.WaitUntilConsensus(t)
-//	}
+// 	assert.NoError(t, txError(testnet.Faucet().Pay(alice, 1000000)))
+// 	alice.WaitUntilBalance(t, 1000000)
 //
-//	// Force ledger to prune graph
-//	alice.ledger.Graph().PruneBelowDepth(alice.ledger.Graph().RootDepth())
+// 	assert.NoError(t, txError(alice.PlaceStake(9001)))
+// 	alice.WaitUntilStake(t, 9001)
 //
-//	// Adding a tx with depth that is too low returns no error as the error is ignored
-//	assert.NoError(t, alice.ledger.AddTransaction(tx))
-//}
+// 	// Alice balance should be balance-stakeAmount-gas
+// 	waitFor(t, func() bool { return alice.Balance() < 1000000-9001 })
 //
-//func TestLedger_Pay(t *testing.T) {
-//	testnet := NewTestNetwork(t)
-//	defer testnet.Cleanup()
+// 	// Everyone else should see the updated balance of Alice
+// 	for _, node := range testnet.Nodes() {
+// 		waitFor(t, func() bool {
+// 			return node.BalanceOfAccount(alice) == alice.Balance() &&
+// 				node.StakeOfAccount(alice) == alice.Stake()
+// 		})
+// 	}
 //
-//	alice := testnet.AddNode(t)
-//	bob := testnet.AddNode(t)
-//
-//	for i := 0; i < 5; i++ {
-//		testnet.AddNode(t)
-//	}
-//
-//	testnet.WaitForSync(t)
-//
-//	assert.NoError(t, txError(testnet.Faucet().Pay(alice, 1000000)))
-//	alice.WaitUntilBalance(t, 1000000)
-//
-//	assert.NoError(t, txError(alice.Pay(bob, 1337)))
-//	bob.WaitUntilBalance(t, 1337)
-//
-//	// Alice balance should be balance-txAmount-gas
-//	waitFor(t, func() bool { return alice.Balance() < 1000000-1337 })
-//
-//	// Everyone else should see the updated balance of Alice and Bob
-//	for _, node := range testnet.Nodes() {
-//		waitFor(t, func() bool {
-//			return node.BalanceOfAccount(alice) == alice.Balance() &&
-//				node.BalanceOfAccount(bob) == 1337
-//		})
-//	}
-//}
-//
-//func TestLedger_PayInsufficientBalance(t *testing.T) {
-//	testnet := NewTestNetwork(t)
-//	defer testnet.Cleanup()
-//
-//	alice := testnet.AddNode(t)
-//	bob := testnet.AddNode(t)
-//
-//	for i := 0; i < 5; i++ {
-//		testnet.AddNode(t)
-//	}
-//
-//	assert.NoError(t, txError(testnet.Faucet().Pay(alice, 1000000)))
-//	alice.WaitUntilBalance(t, 1000000)
-//
-//	// Alice attempt to pay Bob more than what
-//	// she has in her wallet
-//	assert.NoError(t, txError(alice.Pay(bob, 1000001)))
-//	alice.WaitUntilConsensus(t)
-//
-//	// Alice should have paid for gas even though the tx failed
-//	waitFor(t, func() bool {
-//		return alice.Balance() > 0 && alice.Balance() < 1000000
-//	})
-//
-//	// Bob should not receive the tx amount
-//	assert.EqualValues(t, 0, bob.Balance())
-//
-//	// Everyone else should see the updated balance of Alice and Bob
-//	for _, node := range testnet.Nodes() {
-//		waitFor(t, func() bool {
-//			return node.BalanceOfAccount(alice) == alice.Balance() &&
-//				node.BalanceOfAccount(bob) == 0
-//		})
-//	}
-//}
-//
-//func TestLedger_Stake(t *testing.T) {
-//	testnet := NewTestNetwork(t)
-//	defer testnet.Cleanup()
-//
-//	alice := testnet.AddNode(t)
-//
-//	for i := 0; i < 5; i++ {
-//		testnet.AddNode(t)
-//	}
-//
-//	testnet.WaitForSync(t)
-//
-//	assert.NoError(t, txError(testnet.Faucet().Pay(alice, 1000000)))
-//	alice.WaitUntilBalance(t, 1000000)
-//
-//	assert.NoError(t, txError(alice.PlaceStake(9001)))
-//	alice.WaitUntilStake(t, 9001)
-//
-//	// Alice balance should be balance-stakeAmount-gas
-//	waitFor(t, func() bool { return alice.Balance() < 1000000-9001 })
-//
-//	// Everyone else should see the updated balance of Alice
-//	for _, node := range testnet.Nodes() {
-//		waitFor(t, func() bool {
-//			return node.BalanceOfAccount(alice) == alice.Balance() &&
-//				node.StakeOfAccount(alice) == alice.Stake()
-//		})
-//	}
-//
-//	oldBalance := alice.Balance()
-//
-//	assert.NoError(t, txError(alice.WithdrawStake(5000)))
-//	alice.WaitUntilStake(t, 4001)
-//
-//	// Withdrawn stake should be added to balance
-//	waitFor(t, func() bool { return alice.Balance() > oldBalance })
-//
-//	// Everyone else should see the updated balance of Alice
-//	for _, node := range testnet.Nodes() {
-//		waitFor(t, func() bool {
-//			return node.BalanceOfAccount(alice) == alice.Balance() &&
-//				node.StakeOfAccount(alice) == alice.Stake()
-//		})
-//	}
-//}
-//
-//func TestLedger_CallContract(t *testing.T) {
-//	testnet := NewTestNetwork(t)
-//	defer testnet.Cleanup()
-//
-//	alice := testnet.AddNode(t)
-//
-//	for i := 0; i < 5; i++ {
-//		testnet.AddNode(t)
-//	}
-//
-//	testnet.WaitForSync(t)
-//
-//	assert.NoError(t, txError(testnet.Faucet().Pay(alice, 1000000)))
-//	alice.WaitUntilBalance(t, 1000000)
-//
-//	contract, err := alice.SpawnContract("testdata/transfer_back.wasm",
-//		10000, nil)
-//	assert.NoError(t, err)
-//
-//	alice.WaitUntilConsensus(t)
-//
-//	// Calling the contract should cause the contract to send back 250000 PERL back to alice
-//	_, err = alice.CallContract(contract.ID, 500000, 100000, "on_money_received", contract.ID[:])
-//	assert.NoError(t, err)
-//
-//	waitFor(t, func() bool { return alice.Balance() > 700000 })
-//}
-//
-//func TestLedger_DepositGas(t *testing.T) {
-//	testnet := NewTestNetwork(t)
-//	defer testnet.Cleanup()
-//
-//	alice := testnet.AddNode(t)
-//
-//	for i := 0; i < 5; i++ {
-//		testnet.AddNode(t)
-//	}
-//
-//	testnet.WaitForSync(t)
-//
-//	assert.NoError(t, txError(testnet.Faucet().Pay(alice, 1000000)))
-//	alice.WaitUntilBalance(t, 1000000)
-//
-//	contract, err := alice.SpawnContract("testdata/transfer_back.wasm",
-//		10000, nil)
-//	assert.NoError(t, err)
-//
-//	alice.WaitUntilConsensus(t)
-//
-//	assert.NoError(t, txError(alice.DepositGas(contract.ID, 654321)))
-//	waitFor(t, func() bool { return alice.GasBalanceOfAddress(contract.ID) == 654321 })
-//}
-//
-//type account struct {
-//	PublicKey [32]byte
-//	Balance   uint64
-//	Stake     uint64
-//	Reward    uint64
-//}
-//
-//func TestLedger_Sync(t *testing.T) {
-//	testnet := NewTestNetwork(t)
-//	defer testnet.Cleanup()
-//
-//	rand.Seed(time.Now().UnixNano())
-//
-//	var code [1024 * 1024]byte
-//	if _, err := rand.Read(code[:]); err != nil {
-//		t.Fatal(err)
-//	}
-//
-//	// Generate accounts
-//	accounts := make([]account, 500)
-//	for i := 0; i < len(accounts); i++ {
-//		// Use random keys to speed up generation
-//		var key [32]byte
-//		if _, err := rand.Read(key[:]); err != nil {
-//			t.Fatal(err)
-//		}
-//
-//		accounts[i] = account{
-//			PublicKey: key,
-//			Balance:   rand.Uint64(),
-//			Stake:     rand.Uint64(),
-//			Reward:    rand.Uint64(),
-//		}
-//	}
-//
-//	// Setup network with 3 nodes
-//	alice := testnet.Faucet()
-//	for i := 0; i < 2; i++ {
-//		testnet.AddNode(t)
-//	}
-//
-//	testnet.WaitForSync(t)
-//
-//	// Advance the network by a few rounds larger than sys.SyncIfRoundsDifferBy
-//	for i := 0; i < int(conf.GetSyncIfBlockIndicesDifferBy())+1; i++ {
-//		assert.NoError(t, txError(alice.PlaceStake(1)))
-//		alice.WaitUntilConsensus(t)
-//	}
-//
-//	testnet.WaitForRound(t, alice.RoundIndex())
-//
-//	snapshot := testnet.Nodes()[0].ledger.accounts.Snapshot()
-//
-//	snapshot.SetViewID(alice.RoundIndex() + 1)
-//	for _, acc := range accounts {
-//		WriteAccountBalance(snapshot, acc.PublicKey, acc.Balance)
-//		WriteAccountStake(snapshot, acc.PublicKey, acc.Stake)
-//		WriteAccountReward(snapshot, acc.PublicKey, acc.Reward)
-//		WriteAccountContractCode(snapshot, acc.PublicKey, code[:])
-//	}
-//
-//	// Override ledger state of all nodes
-//	for _, node := range testnet.Nodes() {
-//		err := node.ledger.accounts.Commit(snapshot)
-//		if err != nil {
-//			t.Fatal(err)
-//		}
-//
-//		// Override latest round merkle with the new state snapshot
-//		// TODO: this is causing data race
-//		round := node.ledger.rounds.Latest()
-//		round.Merkle = snapshot.Checksum()
-//	}
-//
-//	// When a new node joins the network, it will eventually
-//	// sync with the other nodes
-//	// log.SetWriter(log.ModuleNode, os.Stdout)
-//	charlie := testnet.AddNode(t)
-//
-//	timeout := time.NewTimer(time.Second * 300)
-//	for {
-//		select {
-//		case <-timeout.C:
-//			t.Fatal("timed out waiting for sync")
-//
-//		default:
-//			ri := <-charlie.WaitForRound(alice.RoundIndex())
-//			if ri >= alice.RoundIndex() {
-//				goto DONE
-//			}
-//		}
-//	}
-//
-//DONE:
-//	for _, acc := range accounts {
-//		assert.EqualValues(t, acc.Balance, charlie.BalanceWithPublicKey(acc.PublicKey))
-//		assert.EqualValues(t, acc.Stake, charlie.StakeWithPublicKey(acc.PublicKey))
-//		assert.EqualValues(t, acc.Reward, charlie.RewardWithPublicKey(acc.PublicKey))
-//
-//		checkCode, _ := ReadAccountContractCode(charlie.ledger.accounts.Snapshot(), acc.PublicKey)
-//		assert.True(t, bytes.Equal(code[:], checkCode))
-//	}
-//}
-//
-//func TestLedger_SpamContracts(t *testing.T) {
-//	testnet := NewTestNetwork(t)
-//	defer testnet.Cleanup()
-//
-//	alice := testnet.AddNode(t)
-//	testnet.AddNode(t)
-//
-//	assert.True(t, <-alice.WaitForSync())
-//
-//	assert.NoError(t, txError(testnet.Faucet().Pay(alice, 100000)))
-//	alice.WaitUntilBalance(t, 100000)
-//
-//	// spamming spawn transactions should cause no problem for consensus
-//	// this is possible if they applied in different order on different nodes
-//	for i := 0; i < 5; i++ {
-//		_, err := alice.SpawnContract("testdata/transfer_back.wasm", 10000, nil)
-//		if !assert.NoError(t, err) {
-//			return
-//		}
-//	}
-//
-//	alice.WaitUntilConsensus(t)
-//}
-//
-//func TestLedger_MinimalSync(t *testing.T) {
-//	testnet := NewTestNetwork(t, WithoutFaucet())
-//	defer testnet.Cleanup()
-//
-//	var alice, bob *TestLedger
-//	for i := 0; i < 4; i++ {
-//		switch i {
-//		case 0:
-//			alice = testnet.AddNode(t,
-//				WithWallet(FaucetWallet))
-//			testnet.SetFaucet(alice)
-//
-//		case 1:
-//			bob = testnet.AddNode(t)
-//
-//		default:
-//			testnet.AddNode(t)
-//		}
-//	}
-//
-//	assert.NoError(t, txError(alice.Pay(bob, 100)))
-//	bob.WaitUntilBalance(t, 100)
-//
-//	// End of round 1
-//
-//	charlie := testnet.AddNode(t)
-//	<-charlie.WaitForSync()
-//
-//	assert.NoError(t, txError(alice.Pay(bob, 100)))
-//
-//	bob.WaitUntilBalance(t, 200)
-//	charlie.WaitUntilRound(t, 2)
-//}
-//
-//func txError(tx Transaction, err error) error {
-//	return err
-//}
+// 	oldBalance := alice.Balance()
+//
+// 	assert.NoError(t, txError(alice.WithdrawStake(5000)))
+// 	alice.WaitUntilStake(t, 4001)
+//
+// 	// Withdrawn stake should be added to balance
+// 	waitFor(t, func() bool { return alice.Balance() > oldBalance })
+//
+// 	// Everyone else should see the updated balance of Alice
+// 	for _, node := range testnet.Nodes() {
+// 		waitFor(t, func() bool {
+// 			return node.BalanceOfAccount(alice) == alice.Balance() &&
+// 				node.StakeOfAccount(alice) == alice.Stake()
+// 		})
+// 	}
+// }
+//
+// func TestLedger_CallContract(t *testing.T) {
+// 	testnet := NewTestNetwork(t)
+// 	defer testnet.Cleanup()
+//
+// 	alice := testnet.AddNode(t)
+//
+// 	for i := 0; i < 5; i++ {
+// 		testnet.AddNode(t)
+// 	}
+//
+// 	testnet.WaitForSync(t)
+//
+// 	assert.NoError(t, txError(testnet.Faucet().Pay(alice, 1000000)))
+// 	alice.WaitUntilBalance(t, 1000000)
+//
+// 	contract, err := alice.SpawnContract("testdata/transfer_back.wasm",
+// 		10000, nil)
+// 	assert.NoError(t, err)
+//
+// 	alice.WaitUntilConsensus(t)
+//
+// 	// Calling the contract should cause the contract to send back 250000 PERL back to alice
+// 	_, err = alice.CallContract(contract.ID, 500000, 100000, "on_money_received", contract.ID[:])
+// 	assert.NoError(t, err)
+//
+// 	waitFor(t, func() bool { return alice.Balance() > 700000 })
+// }
+//
+// func TestLedger_DepositGas(t *testing.T) {
+// 	testnet := NewTestNetwork(t)
+// 	defer testnet.Cleanup()
+//
+// 	alice := testnet.AddNode(t)
+//
+// 	for i := 0; i < 5; i++ {
+// 		testnet.AddNode(t)
+// 	}
+//
+// 	testnet.WaitForSync(t)
+//
+// 	assert.NoError(t, txError(testnet.Faucet().Pay(alice, 1000000)))
+// 	alice.WaitUntilBalance(t, 1000000)
+//
+// 	contract, err := alice.SpawnContract("testdata/transfer_back.wasm",
+// 		10000, nil)
+// 	assert.NoError(t, err)
+//
+// 	alice.WaitUntilConsensus(t)
+//
+// 	assert.NoError(t, txError(alice.DepositGas(contract.ID, 654321)))
+// 	waitFor(t, func() bool { return alice.GasBalanceOfAddress(contract.ID) == 654321 })
+// }
+//
+// type account struct {
+// 	PublicKey [32]byte
+// 	Balance   uint64
+// 	Stake     uint64
+// 	Reward    uint64
+// }
+//
+// func TestLedger_Sync(t *testing.T) {
+// 	testnet := NewTestNetwork(t)
+// 	defer testnet.Cleanup()
+//
+// 	rand.Seed(time.Now().UnixNano())
+//
+// 	var code [1024 * 1024]byte
+// 	if _, err := rand.Read(code[:]); err != nil {
+// 		t.Fatal(err)
+// 	}
+//
+// 	// Generate accounts
+// 	accounts := make([]account, 500)
+// 	for i := 0; i < len(accounts); i++ {
+// 		// Use random keys to speed up generation
+// 		var key [32]byte
+// 		if _, err := rand.Read(key[:]); err != nil {
+// 			t.Fatal(err)
+// 		}
+//
+// 		accounts[i] = account{
+// 			PublicKey: key,
+// 			Balance:   rand.Uint64(),
+// 			Stake:     rand.Uint64(),
+// 			Reward:    rand.Uint64(),
+// 		}
+// 	}
+//
+// 	// Setup network with 3 nodes
+// 	alice := testnet.Faucet()
+// 	for i := 0; i < 2; i++ {
+// 		testnet.AddNode(t)
+// 	}
+//
+// 	testnet.WaitForSync(t)
+//
+// 	// Advance the network by a few rounds larger than sys.SyncIfRoundsDifferBy
+// 	for i := 0; i < int(conf.GetSyncIfBlockIndicesDifferBy())+1; i++ {
+// 		assert.NoError(t, txError(alice.PlaceStake(1)))
+// 		alice.WaitUntilConsensus(t)
+// 	}
+//
+// 	testnet.WaitForRound(t, alice.RoundIndex())
+//
+// 	snapshot := testnet.Nodes()[0].ledger.accounts.Snapshot()
+//
+// 	snapshot.SetViewID(alice.RoundIndex() + 1)
+// 	for _, acc := range accounts {
+// 		WriteAccountBalance(snapshot, acc.PublicKey, acc.Balance)
+// 		WriteAccountStake(snapshot, acc.PublicKey, acc.Stake)
+// 		WriteAccountReward(snapshot, acc.PublicKey, acc.Reward)
+// 		WriteAccountContractCode(snapshot, acc.PublicKey, code[:])
+// 	}
+//
+// 	// Override ledger state of all nodes
+// 	for _, node := range testnet.Nodes() {
+// 		err := node.ledger.accounts.Commit(snapshot)
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
+//
+// 		// Override latest round merkle with the new state snapshot
+// 		// TODO: this is causing data race
+// 		round := node.ledger.rounds.Latest()
+// 		round.Merkle = snapshot.Checksum()
+// 	}
+//
+// 	// When a new node joins the network, it will eventually
+// 	// sync with the other nodes
+// 	// log.SetWriter(log.ModuleNode, os.Stdout)
+// 	charlie := testnet.AddNode(t)
+//
+// 	timeout := time.NewTimer(time.Second * 300)
+// 	for {
+// 		select {
+// 		case <-timeout.C:
+// 			t.Fatal("timed out waiting for sync")
+//
+// 		default:
+// 			ri := <-charlie.WaitForRound(alice.RoundIndex())
+// 			if ri >= alice.RoundIndex() {
+// 				goto DONE
+// 			}
+// 		}
+// 	}
+//
+// DONE:
+// 	for _, acc := range accounts {
+// 		assert.EqualValues(t, acc.Balance, charlie.BalanceWithPublicKey(acc.PublicKey))
+// 		assert.EqualValues(t, acc.Stake, charlie.StakeWithPublicKey(acc.PublicKey))
+// 		assert.EqualValues(t, acc.Reward, charlie.RewardWithPublicKey(acc.PublicKey))
+//
+// 		checkCode, _ := ReadAccountContractCode(charlie.ledger.accounts.Snapshot(), acc.PublicKey)
+// 		assert.True(t, bytes.Equal(code[:], checkCode))
+// 	}
+// }
+//
+// func TestLedger_SpamContracts(t *testing.T) {
+// 	testnet := NewTestNetwork(t)
+// 	defer testnet.Cleanup()
+//
+// 	alice := testnet.AddNode(t)
+// 	testnet.AddNode(t)
+//
+// 	assert.True(t, <-alice.WaitForSync())
+//
+// 	assert.NoError(t, txError(testnet.Faucet().Pay(alice, 100000)))
+// 	alice.WaitUntilBalance(t, 100000)
+//
+// 	// spamming spawn transactions should cause no problem for consensus
+// 	// this is possible if they applied in different order on different nodes
+// 	for i := 0; i < 5; i++ {
+// 		_, err := alice.SpawnContract("testdata/transfer_back.wasm", 10000, nil)
+// 		if !assert.NoError(t, err) {
+// 			return
+// 		}
+// 	}
+//
+// 	alice.WaitUntilConsensus(t)
+// }
+//
+// func TestLedger_MinimalSync(t *testing.T) {
+// 	testnet := NewTestNetwork(t, WithoutFaucet())
+// 	defer testnet.Cleanup()
+//
+// 	var alice, bob *TestLedger
+// 	for i := 0; i < 4; i++ {
+// 		switch i {
+// 		case 0:
+// 			alice = testnet.AddNode(t,
+// 				WithWallet(FaucetWallet))
+// 			testnet.SetFaucet(alice)
+//
+// 		case 1:
+// 			bob = testnet.AddNode(t)
+//
+// 		default:
+// 			testnet.AddNode(t)
+// 		}
+// 	}
+//
+// 	assert.NoError(t, txError(alice.Pay(bob, 100)))
+// 	bob.WaitUntilBalance(t, 100)
+//
+// 	// End of round 1
+//
+// 	charlie := testnet.AddNode(t)
+// 	<-charlie.WaitForSync()
+//
+// 	assert.NoError(t, txError(alice.Pay(bob, 100)))
+//
+// 	bob.WaitUntilBalance(t, 200)
+// 	charlie.WaitUntilRound(t, 2)
+// }

--- a/testutil.go
+++ b/testutil.go
@@ -1,580 +1,610 @@
 package wavelet
 
-// var (
-// 	FaucetWallet = "87a6813c3b4cf534b6ae82db9b1409fa7dbd5c13dba5858970b56084c4a930eb400056ee68a7cc2695222df05ea76875bc27ec6e61e8e62317c336157019c405"
-// )
-//
-// type TestNetwork struct {
-// 	faucet *TestLedger
-// 	nodes  map[AccountID]*TestLedger
-// }
-//
-// type TestNetworkConfig struct {
-// 	AddFaucet bool
-// }
-//
-// func defaultTestNetworkConfig() TestNetworkConfig {
-// 	return TestNetworkConfig{
-// 		AddFaucet: true,
-// 	}
-// }
-//
-// type TestNetworkOption func(cfg *TestNetworkConfig)
-//
-// func WithoutFaucet() TestNetworkOption {
-// 	return func(cfg *TestNetworkConfig) {
-// 		cfg.AddFaucet = false
-// 	}
-// }
-//
-// func NewTestNetwork(t testing.TB, opts ...TestNetworkOption) *TestNetwork {
-// 	// Remove existing db
-// 	for i := 0; i < 20; i++ {
-// 		_ = os.RemoveAll(fmt.Sprintf("db_%d", i))
-// 	}
-//
-// 	n := &TestNetwork{
-// 		nodes: map[AccountID]*TestLedger{},
-// 	}
-//
-// 	cfg := defaultTestNetworkConfig()
-// 	for _, opt := range opts {
-// 		opt(&cfg)
-// 	}
-//
-// 	if cfg.AddFaucet {
-// 		n.faucet = n.AddNode(t, WithWallet(FaucetWallet))
-// 	}
-//
-// 	return n
-// }
-//
-// func (n *TestNetwork) Cleanup() {
-// 	for _, node := range n.nodes {
-// 		node.Cleanup()
-// 	}
-//
-// 	// Remove db
-// 	for i := 0; i < 20; i++ {
-// 		_ = os.RemoveAll(fmt.Sprintf("db_%d", i))
-// 	}
-// }
-//
-// func (n *TestNetwork) Faucet() *TestLedger {
-// 	return n.faucet
-// }
-//
-// func (n *TestNetwork) SetFaucet(node *TestLedger) {
-// 	n.faucet = node
-// }
-//
-// type TestLedgerOption func(cfg *TestLedgerConfig)
-//
-// func WithWallet(wallet string) TestLedgerOption {
-// 	return func(cfg *TestLedgerConfig) {
-// 		cfg.Wallet = wallet
-// 	}
-// }
-//
-// func WithKeepExistingDB() TestLedgerOption {
-// 	return func(cfg *TestLedgerConfig) {
-// 		cfg.RemoveExistingDB = false
-// 	}
-// }
-//
-// func WithPeers(peers ...string) TestLedgerOption {
-// 	return func(cfg *TestLedgerConfig) {
-// 		for _, peer := range peers {
-// 			cfg.Peers = append(cfg.Peers, peer)
-// 		}
-// 	}
-// }
-//
-// func WithDBPath(path string) TestLedgerOption {
-// 	return func(cfg *TestLedgerConfig) {
-// 		cfg.DBPath = path
-// 	}
-// }
-//
-// func (n *TestNetwork) AddNode(t testing.TB, opts ...TestLedgerOption) *TestLedger {
-// 	peers := []string{}
-// 	if n.faucet != nil {
-// 		peers = append(peers, n.faucet.Addr())
-// 	}
-//
-// 	cfg := TestLedgerConfig{
-// 		Peers: peers,
-// 		N:     len(n.nodes),
-// 	}
-//
-// 	for _, opt := range opts {
-// 		opt(&cfg)
-// 	}
-//
-// 	node := NewTestLedger(t, cfg)
-// 	node.network = n
-// 	n.nodes[node.PublicKey()] = node
-//
-// 	return node
-// }
-//
-// func (n *TestNetwork) Nodes() []*TestLedger {
-// 	nodes := []*TestLedger{}
-// 	for _, n := range n.nodes {
-// 		nodes = append(nodes, n)
-// 	}
-// 	return nodes
-// }
-//
-// // WaitForRound waits for all the nodes in the network to
-// // reach the specified round.
-// func (n *TestNetwork) WaitForRound(t testing.TB, round uint64) {
-// 	if len(n.nodes) == 0 {
-// 		return
-// 	}
-//
-// 	done := make(chan struct{})
-// 	go func() {
-// 		for _, node := range n.nodes {
-// 			for {
-// 				ri := <-node.WaitForRound(round)
-// 				if ri == round {
-// 					break
-// 				}
-// 			}
-// 		}
-//
-// 		close(done)
-// 	}()
-//
-// 	select {
-// 	case <-time.After(time.Second * 10):
-// 		t.Fatal("timed out waiting for round")
-//
-// 	case <-done:
-// 		return
-// 	}
-// }
-//
-// func (n *TestNetwork) WaitForConsensus(t testing.TB) {
-// 	stop := make(chan struct{})
-// 	var wg sync.WaitGroup
-// 	for _, l := range n.nodes {
-// 		wg.Add(1)
-// 		go func(ledger *TestLedger) {
-// 			defer wg.Done()
-// 			for {
-// 				select {
-// 				case c := <-ledger.WaitForConsensus():
-// 					if c {
-// 						return
-// 					}
-//
-// 				case <-stop:
-// 					return
-// 				}
-// 			}
-//
-// 		}(l)
-// 	}
-//
-// 	done := make(chan struct{})
-// 	go func() {
-// 		wg.Wait()
-// 		close(done)
-// 	}()
-//
-// 	timer := time.NewTimer(10 * time.Second)
-// 	select {
-// 	case <-done:
-// 		close(stop)
-// 		return
-//
-// 	case <-timer.C:
-// 		close(stop)
-// 		<-done
-// 		t.Fatal("consensus round took too long")
-// 	}
-// }
-//
-// func (n *TestNetwork) WaitForSync(t testing.TB) {
-// 	var wg sync.WaitGroup
-// 	for _, l := range n.nodes {
-// 		wg.Add(1)
-// 		go func(ledger *TestLedger) {
-// 			defer wg.Done()
-// 			assert.True(t, <-ledger.WaitForSync())
-// 		}(l)
-// 	}
-//
-// 	done := make(chan struct{})
-// 	go func() {
-// 		wg.Wait()
-// 		close(done)
-// 	}()
-//
-// 	timer := time.NewTimer(5 * time.Second)
-// 	select {
-// 	case <-done:
-// 		return
-// 	case <-timer.C:
-// 		t.Fatal("timeout while waiting for all nodes to be synced")
-// 	}
-// }
-//
-// type TestLedger struct {
-// 	network   *TestNetwork
-// 	ledger    *Ledger
-// 	client    *skademlia.Client
-// 	server    *grpc.Server
-// 	addr      string
-// 	dbPath    string
-// 	kv        store.KV
-// 	kvCleanup func()
-// 	finalized chan struct{}
-// 	stopped   chan struct{}
-// }
-//
-// type TestLedgerConfig struct {
-// 	Wallet           string
-// 	Peers            []string
-// 	N                int
-// 	RemoveExistingDB bool
-// 	DBPath           string
-// }
-//
-// func defaultConfig(t testing.TB) *TestLedgerConfig {
-// 	return &TestLedgerConfig{
-// 		RemoveExistingDB: true,
-// 	}
-// }
-//
-// func NewTestLedger(t testing.TB, cfg TestLedgerConfig) *TestLedger {
-// 	t.Helper()
-//
-// 	keys := loadKeys(t, cfg.Wallet)
-//
-// 	ln, err := net.Listen("tcp", ":0")
-// 	assert.NoError(t, err)
-//
-// 	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(ln.Addr().(*net.TCPAddr).Port))
-//
-// 	client := skademlia.NewClient(addr, keys, skademlia.WithC1(sys.SKademliaC1), skademlia.WithC2(sys.SKademliaC2))
-// 	client.SetCredentials(noise.NewCredentials(addr, handshake.NewECDH(), cipher.NewAEAD(), client.Protocol()))
-//
-// 	kvOpts := []store.TestKVOption{}
-// 	if !cfg.RemoveExistingDB {
-// 		kvOpts = append(kvOpts, store.WithKeepExisting())
-// 	}
-//
-// 	path := fmt.Sprintf("db_%d", cfg.N)
-// 	if cfg.DBPath != "" {
-// 		path = cfg.DBPath
-// 	}
-//
-// 	kv, cleanup := store.NewTestKV(t, "level", path, kvOpts...)
-// 	ledger := NewLedger(kv, client, WithoutGC())
-// 	server := client.Listen()
-// 	RegisterWaveletServer(server, ledger.Protocol())
-//
-// 	stopped := make(chan struct{})
-// 	go func() {
-// 		defer close(stopped)
-// 		if err := server.Serve(ln); err != nil && err != grpc.ErrServerStopped {
-// 			t.Fatal(err)
-// 		}
-// 	}()
-//
-// 	for _, addr := range cfg.Peers {
-// 		if _, err := client.Dial(addr); err != nil {
-// 			t.Fatal(err)
-// 		}
-// 	}
-//
-// 	client.Bootstrap()
-//
-// 	return &TestLedger{
-// 		ledger:    ledger,
-// 		client:    client,
-// 		server:    server,
-// 		addr:      addr,
-// 		dbPath:    path,
-// 		kv:        kv,
-// 		kvCleanup: cleanup,
-// 		stopped:   stopped,
-// 	}
-// }
-//
-// func (l *TestLedger) Leave() {
-// 	l.Cleanup()
-// 	delete(l.network.nodes, l.PublicKey())
-// }
-//
-// func (l *TestLedger) Cleanup() {
-// 	l.server.Stop()
-// 	<-l.stopped
-//
-// 	l.ledger.Close()
-// 	l.kvCleanup()
-// }
-//
-// func (l *TestLedger) Addr() string {
-// 	return l.addr
-// }
-//
-// func (l *TestLedger) Ledger() *Ledger {
-// 	return l.ledger
-// }
-//
-// func (l *TestLedger) Client() *skademlia.Client {
-// 	return l.client
-// }
-//
-// func (l *TestLedger) PrivateKey() edwards25519.PrivateKey {
-// 	keys := l.ledger.client.Keys()
-// 	return keys.PrivateKey()
-// }
-//
-// func (l *TestLedger) PublicKey() AccountID {
-// 	keys := l.ledger.client.Keys()
-// 	return keys.PublicKey()
-// }
-//
-// func (l *TestLedger) DBPath() string {
-// 	return l.dbPath
-// }
-//
-// func (l *TestLedger) Balance() uint64 {
-// 	snapshot := l.ledger.Snapshot()
-// 	balance, _ := ReadAccountBalance(snapshot, l.PublicKey())
-// 	return balance
-// }
-//
-// func (l *TestLedger) BalanceWithPublicKey(key AccountID) uint64 {
-// 	snapshot := l.ledger.Snapshot()
-// 	balance, _ := ReadAccountBalance(snapshot, key)
-// 	return balance
-// }
-//
-// func (l *TestLedger) BalanceOfAccount(node *TestLedger) uint64 {
-// 	snapshot := l.ledger.Snapshot()
-// 	balance, _ := ReadAccountBalance(snapshot, node.PublicKey())
-// 	return balance
-// }
-//
-// func (l *TestLedger) GasBalanceOfAddress(address [32]byte) uint64 {
-// 	snapshot := l.ledger.Snapshot()
-// 	balance, _ := ReadAccountContractGasBalance(snapshot, address)
-// 	return balance
-// }
-//
-// func (l *TestLedger) Stake() uint64 {
-// 	snapshot := l.ledger.Snapshot()
-// 	stake, _ := ReadAccountStake(snapshot, l.PublicKey())
-// 	return stake
-// }
-//
-// func (l *TestLedger) StakeWithPublicKey(key AccountID) uint64 {
-// 	snapshot := l.ledger.Snapshot()
-// 	balance, _ := ReadAccountStake(snapshot, key)
-// 	return balance
-// }
-//
-// func (l *TestLedger) StakeOfAccount(node *TestLedger) uint64 {
-// 	snapshot := l.ledger.Snapshot()
-// 	stake, _ := ReadAccountStake(snapshot, node.PublicKey())
-// 	return stake
-// }
-//
-// func (l *TestLedger) Reward() uint64 {
-// 	snapshot := l.ledger.Snapshot()
-// 	reward, _ := ReadAccountReward(snapshot, l.PublicKey())
-// 	return reward
-// }
-//
-// func (l *TestLedger) RewardWithPublicKey(key AccountID) uint64 {
-// 	snapshot := l.ledger.Snapshot()
-// 	reward, _ := ReadAccountReward(snapshot, key)
-// 	return reward
-// }
-//
-// func (l *TestLedger) RoundIndex() uint64 {
-// 	return l.ledger.Rounds().Latest().Index
-// }
-//
-// func (l *TestLedger) WaitForConsensus() <-chan bool {
-// 	ch := make(chan bool)
-// 	go func() {
-// 		start := l.ledger.Rounds().Latest()
-// 		timeout := time.NewTimer(time.Second * 3)
-// 		ticker := time.NewTicker(time.Millisecond * 5)
-//
-// 		for {
-// 			select {
-// 			case <-timeout.C:
-// 				ch <- false
-// 				return
-//
-// 			case <-ticker.C:
-// 				current := l.ledger.Rounds().Latest()
-// 				if current.Index > start.Index {
-// 					ch <- true
-// 					return
-// 				}
-// 			}
-// 		}
-// 	}()
-//
-// 	return ch
-// }
-//
-// func (l *TestLedger) WaitUntilConsensus(t testing.TB) {
-// 	t.Helper()
-//
-// 	timeout := time.NewTimer(time.Second * 30)
-// 	for {
-// 		select {
-// 		case c := <-l.WaitForConsensus():
-// 			if c {
-// 				return
-// 			}
-//
-// 		case <-timeout.C:
-// 			t.Fatal("timed out waiting for consensus")
-// 		}
-// 	}
-// }
-//
-// // WaitUntilBalance should be used to ensure that the ledger's balance
-// // is of a specific value before continuing.
-// func (l *TestLedger) WaitUntilBalance(t testing.TB, balance uint64) {
-// 	t.Helper()
-//
-// 	ticker := time.NewTicker(time.Millisecond * 200)
-// 	timeout := time.NewTimer(time.Second * 30)
-// 	for {
-// 		select {
-// 		case <-ticker.C:
-// 			if l.Balance() == balance {
-// 				return
-// 			}
-//
-// 		case <-timeout.C:
-// 			t.Fatal("timed out waiting for balance")
-// 		}
-// 	}
-// }
-//
-// func (l *TestLedger) WaitUntilStake(t testing.TB, stake uint64) {
-// 	t.Helper()
-//
-// 	ticker := time.NewTicker(time.Millisecond * 200)
-// 	timeout := time.NewTimer(time.Second * 30)
-// 	for {
-// 		select {
-// 		case <-ticker.C:
-// 			if l.Stake() == stake {
-// 				return
-// 			}
-//
-// 		case <-timeout.C:
-// 			t.Fatal("timed out waiting for stake")
-// 		}
-// 	}
-// }
-//
-// func (l *TestLedger) WaitForRound(index uint64) <-chan uint64 {
-// 	ch := make(chan uint64)
-// 	go func() {
-// 		timeout := time.NewTimer(time.Second * 3)
-// 		ticker := time.NewTicker(time.Millisecond * 10)
-//
-// 		for {
-// 			select {
-// 			case <-timeout.C:
-// 				ch <- 0
-// 				return
-//
-// 			case <-ticker.C:
-// 				current := l.ledger.Rounds().Latest()
-// 				if current.Index >= index {
-// 					ch <- current.Index
-// 					return
-// 				}
-// 			}
-// 		}
-// 	}()
-//
-// 	return ch
-// }
-//
-// func (l *TestLedger) WaitUntilRound(t testing.TB, round uint64) {
-// 	t.Helper()
-//
-// 	timeout := time.NewTimer(time.Second * 30)
-// 	for {
-// 		select {
-// 		case ri := <-l.WaitForRound(round):
-// 			if ri >= round {
-// 				return
-// 			}
-//
-// 		case <-timeout.C:
-// 			t.Fatal("timed out waiting for round")
-// 		}
-// 	}
-// }
-//
-// func (l *TestLedger) WaitForSync() <-chan bool {
-// 	ch := make(chan bool)
-// 	go func() {
-// 		timeout := time.NewTimer(time.Second * 3)
-// 		ticker := time.NewTicker(time.Millisecond * 50)
-// 		for {
-// 			select {
-// 			case <-timeout.C:
-// 				ch <- false
-// 				return
-//
-// 			case <-ticker.C:
-// 				if l.ledger.SyncStatus() == "Node is fully synced" {
-// 					ch <- true
-// 					return
-// 				}
-// 			}
-// 		}
-// 	}()
-//
-// 	return ch
-// }
-//
-// func (l *TestLedger) Nop() (Transaction, error) {
-// 	keys := l.ledger.client.Keys()
-// 	tx := AttachSenderToTransaction(
-// 		keys,
-// 		NewTransaction(sys.TagTransfer, nil),
-// 		l.ledger.Graph().FindEligibleParents()...)
-//
-// 	err := l.ledger.AddTransaction(tx)
-// 	return tx, err
-// }
-//
-// func (l *TestLedger) Pay(to *TestLedger, amount uint64) (Transaction, error) {
-// 	payload := Transfer{
-// 		Recipient: to.PublicKey(),
-// 		Amount:    amount,
-// 	}
-//
-// 	keys := l.ledger.client.Keys()
-// 	tx := AttachSenderToTransaction(
-// 		keys,
-// 		NewTransaction(sys.TagTransfer, payload.Marshal()),
-// 		l.ledger.Graph().FindEligibleParents()...)
-//
-// 	err := l.ledger.AddTransaction(tx)
-// 	return tx, err
-// }
-//
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/perlin-network/noise"
+	"github.com/perlin-network/noise/cipher"
+	"github.com/perlin-network/noise/edwards25519"
+	"github.com/perlin-network/noise/handshake"
+	"github.com/perlin-network/noise/skademlia"
+	"github.com/perlin-network/wavelet/store"
+	"github.com/perlin-network/wavelet/sys"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+)
+
+var (
+	FaucetWallet = "87a6813c3b4cf534b6ae82db9b1409fa7dbd5c13dba5858970b56084c4a930eb400056ee68a7cc2695222df05ea76875bc27ec6e61e8e62317c336157019c405"
+)
+
+type TestNetwork struct {
+	faucet *TestLedger
+	nodes  map[AccountID]*TestLedger
+}
+
+type TestNetworkConfig struct {
+	AddFaucet bool
+}
+
+func defaultTestNetworkConfig() TestNetworkConfig {
+	return TestNetworkConfig{
+		AddFaucet: true,
+	}
+}
+
+type TestNetworkOption func(cfg *TestNetworkConfig)
+
+func WithoutFaucet() TestNetworkOption {
+	return func(cfg *TestNetworkConfig) {
+		cfg.AddFaucet = false
+	}
+}
+
+func NewTestNetwork(t testing.TB, opts ...TestNetworkOption) *TestNetwork {
+	// Remove existing db
+	for i := 0; i < 20; i++ {
+		_ = os.RemoveAll(fmt.Sprintf("db_%d", i))
+	}
+
+	n := &TestNetwork{
+		nodes: map[AccountID]*TestLedger{},
+	}
+
+	cfg := defaultTestNetworkConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	if cfg.AddFaucet {
+		n.faucet = n.AddNode(t, WithWallet(FaucetWallet))
+	}
+
+	return n
+}
+
+func (n *TestNetwork) Cleanup() {
+	for _, node := range n.nodes {
+		node.Cleanup()
+	}
+
+	// Remove db
+	for i := 0; i < 20; i++ {
+		_ = os.RemoveAll(fmt.Sprintf("db_%d", i))
+	}
+}
+
+func (n *TestNetwork) Faucet() *TestLedger {
+	return n.faucet
+}
+
+func (n *TestNetwork) SetFaucet(node *TestLedger) {
+	n.faucet = node
+}
+
+type TestLedgerOption func(cfg *TestLedgerConfig)
+
+func WithWallet(wallet string) TestLedgerOption {
+	return func(cfg *TestLedgerConfig) {
+		cfg.Wallet = wallet
+	}
+}
+
+func WithKeepExistingDB() TestLedgerOption {
+	return func(cfg *TestLedgerConfig) {
+		cfg.RemoveExistingDB = false
+	}
+}
+
+func WithPeers(peers ...string) TestLedgerOption {
+	return func(cfg *TestLedgerConfig) {
+		for _, peer := range peers {
+			cfg.Peers = append(cfg.Peers, peer)
+		}
+	}
+}
+
+func WithDBPath(path string) TestLedgerOption {
+	return func(cfg *TestLedgerConfig) {
+		cfg.DBPath = path
+	}
+}
+
+func (n *TestNetwork) AddNode(t testing.TB, opts ...TestLedgerOption) *TestLedger {
+	peers := []string{}
+	if n.faucet != nil {
+		peers = append(peers, n.faucet.Addr())
+	}
+
+	cfg := TestLedgerConfig{
+		Peers: peers,
+		N:     len(n.nodes),
+	}
+
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	node := NewTestLedger(t, cfg)
+	node.network = n
+	n.nodes[node.PublicKey()] = node
+
+	return node
+}
+
+func (n *TestNetwork) Nodes() []*TestLedger {
+	nodes := []*TestLedger{}
+	for _, n := range n.nodes {
+		nodes = append(nodes, n)
+	}
+	return nodes
+}
+
+// WaitForRound waits for all the nodes in the network to
+// reach the specified round.
+func (n *TestNetwork) WaitForBlock(t testing.TB, round uint64) {
+	if len(n.nodes) == 0 {
+		return
+	}
+
+	done := make(chan struct{})
+	go func() {
+		for _, node := range n.nodes {
+			for {
+				ri := <-node.WaitForBlock(round)
+				if ri == round {
+					break
+				}
+			}
+		}
+
+		close(done)
+	}()
+
+	select {
+	case <-time.After(time.Second * 10):
+		t.Fatal("timed out waiting for round")
+
+	case <-done:
+		return
+	}
+}
+
+func (n *TestNetwork) WaitForConsensus(t testing.TB) {
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for _, l := range n.nodes {
+		wg.Add(1)
+		go func(ledger *TestLedger) {
+			defer wg.Done()
+			for {
+				select {
+				case c := <-ledger.WaitForConsensus():
+					if c {
+						return
+					}
+
+				case <-stop:
+					return
+				}
+			}
+
+		}(l)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	timer := time.NewTimer(10 * time.Second)
+	select {
+	case <-done:
+		close(stop)
+		return
+
+	case <-timer.C:
+		close(stop)
+		<-done
+		t.Fatal("consensus round took too long")
+	}
+}
+
+func (n *TestNetwork) WaitForSync(t testing.TB) {
+	var wg sync.WaitGroup
+	for _, l := range n.nodes {
+		wg.Add(1)
+		go func(ledger *TestLedger) {
+			defer wg.Done()
+			assert.True(t, <-ledger.WaitForSync())
+		}(l)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	timer := time.NewTimer(5 * time.Second)
+	select {
+	case <-done:
+		return
+	case <-timer.C:
+		t.Fatal("timeout while waiting for all nodes to be synced")
+	}
+}
+
+type TestLedger struct {
+	network   *TestNetwork
+	nonce     uint64
+	ledger    *Ledger
+	client    *skademlia.Client
+	server    *grpc.Server
+	addr      string
+	dbPath    string
+	kv        store.KV
+	kvCleanup func()
+	finalized chan struct{}
+	stopped   chan struct{}
+}
+
+type TestLedgerConfig struct {
+	Wallet           string
+	Peers            []string
+	N                int
+	RemoveExistingDB bool
+	DBPath           string
+}
+
+func defaultConfig(t testing.TB) *TestLedgerConfig {
+	return &TestLedgerConfig{
+		RemoveExistingDB: true,
+	}
+}
+
+func NewTestLedger(t testing.TB, cfg TestLedgerConfig) *TestLedger {
+	t.Helper()
+
+	keys := loadKeys(t, cfg.Wallet)
+
+	ln, err := net.Listen("tcp", ":0")
+	assert.NoError(t, err)
+
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(ln.Addr().(*net.TCPAddr).Port))
+
+	client := skademlia.NewClient(addr, keys, skademlia.WithC1(sys.SKademliaC1), skademlia.WithC2(sys.SKademliaC2))
+	client.SetCredentials(noise.NewCredentials(addr, handshake.NewECDH(), cipher.NewAEAD(), client.Protocol()))
+
+	kvOpts := []store.TestKVOption{}
+	if !cfg.RemoveExistingDB {
+		kvOpts = append(kvOpts, store.WithKeepExisting())
+	}
+
+	path := fmt.Sprintf("db_%d", cfg.N)
+	if cfg.DBPath != "" {
+		path = cfg.DBPath
+	}
+
+	kv, cleanup := store.NewTestKV(t, "level", path, kvOpts...)
+	ledger := NewLedger(kv, client, WithoutGC())
+	server := client.Listen()
+	RegisterWaveletServer(server, ledger.Protocol())
+
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		if err := server.Serve(ln); err != nil && err != grpc.ErrServerStopped {
+			t.Fatal(err)
+		}
+	}()
+
+	for _, addr := range cfg.Peers {
+		if _, err := client.Dial(addr); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	client.Bootstrap()
+
+	return &TestLedger{
+		ledger:    ledger,
+		client:    client,
+		server:    server,
+		addr:      addr,
+		dbPath:    path,
+		kv:        kv,
+		kvCleanup: cleanup,
+		stopped:   stopped,
+	}
+}
+
+func (l *TestLedger) Leave() {
+	l.Cleanup()
+	delete(l.network.nodes, l.PublicKey())
+}
+
+func (l *TestLedger) Cleanup() {
+	l.server.Stop()
+	<-l.stopped
+
+	l.ledger.Close()
+	l.kvCleanup()
+}
+
+func (l *TestLedger) Addr() string {
+	return l.addr
+}
+
+func (l *TestLedger) Ledger() *Ledger {
+	return l.ledger
+}
+
+func (l *TestLedger) Client() *skademlia.Client {
+	return l.client
+}
+
+func (l *TestLedger) PrivateKey() edwards25519.PrivateKey {
+	keys := l.ledger.client.Keys()
+	return keys.PrivateKey()
+}
+
+func (l *TestLedger) PublicKey() AccountID {
+	keys := l.ledger.client.Keys()
+	return keys.PublicKey()
+}
+
+func (l *TestLedger) DBPath() string {
+	return l.dbPath
+}
+
+func (l *TestLedger) Balance() uint64 {
+	snapshot := l.ledger.Snapshot()
+	balance, _ := ReadAccountBalance(snapshot, l.PublicKey())
+	return balance
+}
+
+func (l *TestLedger) BalanceWithPublicKey(key AccountID) uint64 {
+	snapshot := l.ledger.Snapshot()
+	balance, _ := ReadAccountBalance(snapshot, key)
+	return balance
+}
+
+func (l *TestLedger) BalanceOfAccount(node *TestLedger) uint64 {
+	snapshot := l.ledger.Snapshot()
+	balance, _ := ReadAccountBalance(snapshot, node.PublicKey())
+	return balance
+}
+
+func (l *TestLedger) GasBalanceOfAddress(address [32]byte) uint64 {
+	snapshot := l.ledger.Snapshot()
+	balance, _ := ReadAccountContractGasBalance(snapshot, address)
+	return balance
+}
+
+func (l *TestLedger) Stake() uint64 {
+	snapshot := l.ledger.Snapshot()
+	stake, _ := ReadAccountStake(snapshot, l.PublicKey())
+	return stake
+}
+
+func (l *TestLedger) StakeWithPublicKey(key AccountID) uint64 {
+	snapshot := l.ledger.Snapshot()
+	balance, _ := ReadAccountStake(snapshot, key)
+	return balance
+}
+
+func (l *TestLedger) StakeOfAccount(node *TestLedger) uint64 {
+	snapshot := l.ledger.Snapshot()
+	stake, _ := ReadAccountStake(snapshot, node.PublicKey())
+	return stake
+}
+
+func (l *TestLedger) Reward() uint64 {
+	snapshot := l.ledger.Snapshot()
+	reward, _ := ReadAccountReward(snapshot, l.PublicKey())
+	return reward
+}
+
+func (l *TestLedger) RewardWithPublicKey(key AccountID) uint64 {
+	snapshot := l.ledger.Snapshot()
+	reward, _ := ReadAccountReward(snapshot, key)
+	return reward
+}
+
+func (l *TestLedger) BlockIndex() uint64 {
+	return l.ledger.Blocks().Latest().Index
+}
+
+func (l *TestLedger) WaitForConsensus() <-chan bool {
+	ch := make(chan bool)
+	go func() {
+		start := l.ledger.Blocks().Latest()
+		timeout := time.NewTimer(time.Second * 3)
+		ticker := time.NewTicker(time.Millisecond * 5)
+
+		for {
+			select {
+			case <-timeout.C:
+				ch <- false
+				return
+
+			case <-ticker.C:
+				current := l.ledger.Blocks().Latest()
+				if current.Index > start.Index {
+					ch <- true
+					return
+				}
+			}
+		}
+	}()
+
+	return ch
+}
+
+func (l *TestLedger) WaitUntilConsensus(t testing.TB) {
+	t.Helper()
+
+	timeout := time.NewTimer(time.Second * 30)
+	for {
+		select {
+		case c := <-l.WaitForConsensus():
+			if c {
+				return
+			}
+
+		case <-timeout.C:
+			t.Fatal("timed out waiting for consensus")
+		}
+	}
+}
+
+// WaitUntilBalance should be used to ensure that the ledger's balance
+// is of a specific value before continuing.
+func (l *TestLedger) WaitUntilBalance(t testing.TB, balance uint64) {
+	t.Helper()
+
+	ticker := time.NewTicker(time.Millisecond * 200)
+	timeout := time.NewTimer(time.Second * 30)
+	for {
+		select {
+		case <-ticker.C:
+			if l.Balance() == balance {
+				return
+			}
+
+		case <-timeout.C:
+			t.Fatal("timed out waiting for balance")
+		}
+	}
+}
+
+func (l *TestLedger) WaitUntilStake(t testing.TB, stake uint64) {
+	t.Helper()
+
+	ticker := time.NewTicker(time.Millisecond * 200)
+	timeout := time.NewTimer(time.Second * 30)
+	for {
+		select {
+		case <-ticker.C:
+			if l.Stake() == stake {
+				return
+			}
+
+		case <-timeout.C:
+			t.Fatal("timed out waiting for stake")
+		}
+	}
+}
+
+func (l *TestLedger) WaitForBlock(index uint64) <-chan uint64 {
+	ch := make(chan uint64)
+	go func() {
+		timeout := time.NewTimer(time.Second * 3)
+		ticker := time.NewTicker(time.Millisecond * 10)
+
+		for {
+			select {
+			case <-timeout.C:
+				ch <- 0
+				return
+
+			case <-ticker.C:
+				current := l.ledger.Blocks().Latest()
+				if current.Index >= index {
+					ch <- current.Index
+					return
+				}
+			}
+		}
+	}()
+
+	return ch
+}
+
+func (l *TestLedger) WaitUntilBlock(t testing.TB, round uint64) {
+	t.Helper()
+
+	timeout := time.NewTimer(time.Second * 30)
+	for {
+		select {
+		case ri := <-l.WaitForBlock(round):
+			if ri >= round {
+				return
+			}
+
+		case <-timeout.C:
+			t.Fatal("timed out waiting for round")
+		}
+	}
+}
+
+func (l *TestLedger) WaitForSync() <-chan bool {
+	ch := make(chan bool)
+	go func() {
+		timeout := time.NewTimer(time.Second * 3)
+		ticker := time.NewTicker(time.Millisecond * 50)
+		for {
+			select {
+			case <-timeout.C:
+				ch <- false
+				return
+
+			case <-ticker.C:
+				if l.ledger.SyncStatus() == "Node is fully synced" {
+					ch <- true
+					return
+				}
+			}
+		}
+	}()
+
+	return ch
+}
+
+func (l *TestLedger) newSignedTransaction(tag sys.Tag, payload []byte) Transaction {
+	nonce := atomic.AddUint64(&l.nonce, 1)
+	block := l.BlockIndex()
+
+	var nonceBuf [8]byte
+	binary.BigEndian.PutUint64(nonceBuf[:], nonce)
+
+	var blockBuf [8]byte
+	binary.BigEndian.PutUint64(blockBuf[:], block)
+
+	keys := l.ledger.client.Keys()
+	signature := edwards25519.Sign(
+		keys.PrivateKey(),
+		append(nonceBuf[:], append(blockBuf[:], append([]byte{byte(tag)}, payload...)...)...),
+	)
+
+	return NewSignedTransaction(
+		keys.PublicKey(), nonce, block,
+		tag, payload, signature,
+	)
+}
+
+func (l *TestLedger) Pay(to *TestLedger, amount uint64) Transaction {
+	payload := Transfer{
+		Recipient: to.PublicKey(),
+		Amount:    amount,
+	}
+
+	tx := l.newSignedTransaction(sys.TagTransfer, payload.Marshal())
+	l.ledger.AddTransaction(tx)
+	return tx
+}
+
 // func (l *TestLedger) SpawnContract(contractPath string, gasLimit uint64, params []byte) (Transaction, error) {
 // 	code, err := ioutil.ReadFile(contractPath)
 // 	if err != nil {
@@ -706,73 +736,73 @@ package wavelet
 // func (l *TestLedger) Applied(tx Transaction) bool {
 // 	return tx.Depth <= l.ledger.Graph().RootDepth()
 // }
-//
-// // loadKeys returns a keypair from a wallet string, or generates a new one
-// // if no wallet is provided.
-// func loadKeys(t testing.TB, wallet string) *skademlia.Keypair {
-// 	// Generate a keypair if wallet is empty
-// 	if wallet == "" {
-// 		keys, err := skademlia.NewKeys(sys.SKademliaC1, sys.SKademliaC2)
-// 		assert.NoError(t, err)
-// 		return keys
-// 	}
-//
-// 	if len(wallet) != hex.EncodedLen(edwards25519.SizePrivateKey) {
-// 		t.Fatal(fmt.Errorf("private key is not of the right length"))
-// 	}
-//
-// 	var privateKey edwards25519.PrivateKey
-// 	n, err := hex.Decode(privateKey[:], []byte(wallet))
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-//
-// 	if n != edwards25519.SizePrivateKey {
-// 		t.Fatal(fmt.Errorf("private key is not of the right length"))
-// 	}
-//
-// 	keys, err := skademlia.LoadKeys(privateKey, sys.SKademliaC1, sys.SKademliaC2)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-//
-// 	return keys
-// }
-//
-// func waitFor(t testing.TB, fn func() bool) {
-// 	t.Helper()
-//
-// 	timeout := time.NewTimer(time.Second * 30)
-// 	ticker := time.NewTicker(time.Millisecond * 100)
-//
-// 	for {
-// 		select {
-// 		case <-timeout.C:
-// 			t.Fatal("timed out waiting")
-//
-// 		case <-ticker.C:
-// 			if fn() {
-// 				return
-// 			}
-// 		}
-// 	}
-// }
-//
-// func waitForDuration(t testing.TB, fn func() bool, d time.Duration) {
-// 	t.Helper()
-//
-// 	timeout := time.NewTimer(d)
-// 	ticker := time.NewTicker(time.Millisecond * 100)
-//
-// 	for {
-// 		select {
-// 		case <-timeout.C:
-// 			t.Fatal("timed out waiting")
-//
-// 		case <-ticker.C:
-// 			if fn() {
-// 				return
-// 			}
-// 		}
-// 	}
-// }
+
+// loadKeys returns a keypair from a wallet string, or generates a new one
+// if no wallet is provided.
+func loadKeys(t testing.TB, wallet string) *skademlia.Keypair {
+	// Generate a keypair if wallet is empty
+	if wallet == "" {
+		keys, err := skademlia.NewKeys(sys.SKademliaC1, sys.SKademliaC2)
+		assert.NoError(t, err)
+		return keys
+	}
+
+	if len(wallet) != hex.EncodedLen(edwards25519.SizePrivateKey) {
+		t.Fatal(fmt.Errorf("private key is not of the right length"))
+	}
+
+	var privateKey edwards25519.PrivateKey
+	n, err := hex.Decode(privateKey[:], []byte(wallet))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if n != edwards25519.SizePrivateKey {
+		t.Fatal(fmt.Errorf("private key is not of the right length"))
+	}
+
+	keys, err := skademlia.LoadKeys(privateKey, sys.SKademliaC1, sys.SKademliaC2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return keys
+}
+
+func waitFor(t testing.TB, fn func() bool) {
+	t.Helper()
+
+	timeout := time.NewTimer(time.Second * 30)
+	ticker := time.NewTicker(time.Millisecond * 100)
+
+	for {
+		select {
+		case <-timeout.C:
+			t.Fatal("timed out waiting")
+
+		case <-ticker.C:
+			if fn() {
+				return
+			}
+		}
+	}
+}
+
+func waitForDuration(t testing.TB, fn func() bool, d time.Duration) {
+	t.Helper()
+
+	timeout := time.NewTimer(d)
+	ticker := time.NewTicker(time.Millisecond * 100)
+
+	for {
+		select {
+		case <-timeout.C:
+			t.Fatal("timed out waiting")
+
+		case <-ticker.C:
+			if fn() {
+				return
+			}
+		}
+	}
+}

--- a/testutil.go
+++ b/testutil.go
@@ -553,7 +553,7 @@ func (l *TestLedger) WaitUntilBlock(t testing.TB, round uint64) {
 func (l *TestLedger) WaitForSync() <-chan bool {
 	ch := make(chan bool)
 	go func() {
-		timeout := time.NewTimer(time.Second * 3)
+		timeout := time.NewTimer(time.Second * 10)
 		ticker := time.NewTicker(time.Millisecond * 50)
 		for {
 			select {

--- a/testutil.go
+++ b/testutil.go
@@ -680,39 +680,29 @@ func (l *TestLedger) Pay(to *TestLedger, amount uint64) Transaction {
 // 	err := l.ledger.AddTransaction(tx)
 // 	return tx, err
 // }
-//
-// func (l *TestLedger) PlaceStake(amount uint64) (Transaction, error) {
-// 	payload := Stake{
-// 		Opcode: sys.PlaceStake,
-// 		Amount: amount,
-// 	}
-//
-// 	keys := l.ledger.client.Keys()
-// 	tx := AttachSenderToTransaction(
-// 		keys,
-// 		NewTransaction(sys.TagStake, payload.Marshal()),
-// 		l.ledger.Graph().FindEligibleParents()...)
-//
-// 	err := l.ledger.AddTransaction(tx)
-// 	return tx, err
-// }
-//
-// func (l *TestLedger) WithdrawStake(amount uint64) (Transaction, error) {
-// 	payload := Stake{
-// 		Opcode: sys.WithdrawStake,
-// 		Amount: amount,
-// 	}
-//
-// 	keys := l.ledger.client.Keys()
-// 	tx := AttachSenderToTransaction(
-// 		keys,
-// 		NewTransaction(sys.TagStake, payload.Marshal()),
-// 		l.ledger.Graph().FindEligibleParents()...)
-//
-// 	err := l.ledger.AddTransaction(tx)
-// 	return tx, err
-// }
-//
+
+func (l *TestLedger) PlaceStake(amount uint64) Transaction {
+	payload := Stake{
+		Opcode: sys.PlaceStake,
+		Amount: amount,
+	}
+
+	tx := l.newSignedTransaction(sys.TagStake, payload.Marshal())
+	l.ledger.AddTransaction(tx)
+	return tx
+}
+
+func (l *TestLedger) WithdrawStake(amount uint64) Transaction {
+	payload := Stake{
+		Opcode: sys.WithdrawStake,
+		Amount: amount,
+	}
+
+	tx := l.newSignedTransaction(sys.TagStake, payload.Marshal())
+	l.ledger.AddTransaction(tx)
+	return tx
+}
+
 // func (l *TestLedger) WithdrawReward(amount uint64) (Transaction, error) {
 // 	payload := Stake{
 // 		Opcode: sys.WithdrawReward,

--- a/tx_applier_test.go
+++ b/tx_applier_test.go
@@ -19,394 +19,429 @@
 
 package wavelet
 
-//import (
-//	"io/ioutil"
-//	"math/rand"
-//	"testing"
-//
-//	"github.com/perlin-network/noise/skademlia"
-//	"github.com/perlin-network/wavelet/avl"
-//	"github.com/perlin-network/wavelet/store"
-//	"github.com/perlin-network/wavelet/sys"
-//	"github.com/stretchr/testify/assert"
-//)
-//
-//type testAccount struct {
-//	keys   *skademlia.Keypair
-//	effect struct {
-//		Balance uint64
-//		Stake   uint64
-//	}
-//}
-//
-//func TestApplyTransaction_Single(t *testing.T) {
-//	t.Parallel()
-//
-//	const InitialBalance = 100000000
-//
-//	state := avl.New(store.NewInmem())
-//	var initialRoot Transaction
-//
-//	viewID := uint64(0)
-//	state.SetViewID(viewID)
-//
-//	accounts := make(map[AccountID]*testAccount)
-//	accountIDs := make([]AccountID, 0)
-//
-//	for i := 0; i < 60; i++ {
-//		keys, err := skademlia.NewKeys(1, 1)
-//		assert.NoError(t, err)
-//		account := &testAccount{
-//			keys: keys,
-//		}
-//		if i == 0 {
-//			initialRoot = AttachSenderToTransaction(keys, NewTransaction(sys.TagNop, nil))
-//		}
-//		WriteAccountBalance(state, keys.PublicKey(), InitialBalance)
-//		account.effect.Balance = InitialBalance
-//
-//		accounts[keys.PublicKey()] = account
-//		accountIDs = append(accountIDs, keys.PublicKey())
-//	}
-//
-//	rng := rand.New(rand.NewSource(42))
-//
-//	block := NewBlock(viewID, state.Checksum(), 0, Transaction{}, initialRoot)
-//
-//	for i := 0; i < 10000; i++ {
-//		switch rng.Intn(2) {
-//		case 0:
-//			amount := rng.Uint64()%100 + 1
-//
-//			account := accounts[accountIDs[rng.Intn(len(accountIDs))]]
-//			account.effect.Stake += amount
-//			account.effect.Balance -= amount
-//
-//			tx := AttachSenderToTransaction(account.keys, NewTransaction(sys.TagStake, buildPlaceStakePayload(amount).Marshal()))
-//			assert.NoError(t, ApplyTransaction(state, &round, &tx))
-//		case 1:
-//			amount := rng.Uint64()%100 + 1
-//
-//			fromAccount := accounts[accountIDs[rng.Intn(len(accountIDs))]]
-//			toAccount := accounts[accountIDs[rng.Intn(len(accountIDs))]]
-//
-//			if fromAccount.keys.PublicKey() == toAccount.keys.PublicKey() {
-//				continue
-//			}
-//
-//			toAccountID := toAccount.keys.PublicKey()
-//
-//			fromAccount.effect.Balance -= amount
-//			toAccount.effect.Balance += amount
-//
-//			tx := AttachSenderToTransaction(fromAccount.keys, NewTransaction(sys.TagTransfer, buildTransferPayload(toAccountID, amount).Marshal()))
-//			assert.NoError(t, ApplyTransaction(state, &round, &tx))
-//		default:
-//			panic("unreachable")
-//		}
-//	}
-//
-//	for id, account := range accounts {
-//		stake, _ := ReadAccountStake(state, id)
-//		assert.Equal(t, stake, account.effect.Stake)
-//
-//		balance, _ := ReadAccountBalance(state, id)
-//		assert.Equal(t, balance, account.effect.Balance)
-//	}
-//}
-//
-//func TestApplyTransaction_Collapse(t *testing.T) {
-//	t.Parallel()
-//
-//	const InitialBalance = 100000000
-//
-//	stateStore := store.NewInmem()
-//	state := avl.New(stateStore)
-//	var initialRoot Transaction
-//
-//	viewID := uint64(0)
-//	state.SetViewID(viewID)
-//
-//	var graph *Graph
-//
-//	accounts := make(map[AccountID]*testAccount)
-//	accountIDs := make([]AccountID, 0)
-//	for i := 0; i < 60; i++ {
-//		keys, err := skademlia.NewKeys(1, 1)
-//		assert.NoError(t, err)
-//		account := &testAccount{
-//			keys: keys,
-//		}
-//		if i == 0 {
-//			initialRoot = AttachSenderToTransaction(keys, NewTransaction(sys.TagNop, nil))
-//			graph = NewGraph(WithRoot(initialRoot))
-//		}
-//		WriteAccountBalance(state, keys.PublicKey(), InitialBalance)
-//		account.effect.Balance = InitialBalance
-//
-//		accounts[keys.PublicKey()] = account
-//		accountIDs = append(accountIDs, keys.PublicKey())
-//	}
-//
-//	assert.NotNil(t, graph)
-//
-//	rng := rand.New(rand.NewSource(42))
-//	block := NewBlock(viewID, state.Checksum(), 0, Transaction{}, initialRoot)
-//
-//	accountState := NewAccounts(stateStore)
-//	assert.NoError(t, accountState.Commit(state))
-//
-//	var criticalCount int
-//
-//	for criticalCount < 100 {
-//		amount := rng.Uint64()%100 + 1
-//		account := accounts[accountIDs[rng.Intn(len(accountIDs))]]
-//		account.effect.Stake += amount
-//
-//		tx := AttachSenderToTransaction(account.keys, NewTransaction(sys.TagStake, buildPlaceStakePayload(amount).Marshal()), graph.FindEligibleParents()...)
-//		assert.NoError(t, graph.AddTransaction(tx))
-//
-//		if tx.IsCritical(4) {
-//			results, err := collapseTransactions(graph, accountState, viewID+1, &round, round.End, tx, false)
-//			assert.NoError(t, err)
-//			err = accountState.Commit(results.snapshot)
-//			assert.NoError(t, err)
-//			state = results.snapshot
-//			round = NewRound(viewID+1, state.Checksum(), uint32(results.appliedCount+results.rejectedCount), round.End, tx)
-//			viewID += 1
-//
-//			for id, account := range accounts {
-//				stake, _ := ReadAccountStake(state, id)
-//				assert.Equal(t, stake, account.effect.Stake)
-//			}
-//			criticalCount++
-//		}
-//	}
-//}
-//
-//func TestApplyTransferTransaction(t *testing.T) {
-//	t.Parallel()
-//
-//	state := avl.New(store.NewInmem())
-//	block := NewBlock(0, state.Checksum(), 0, Transaction{}, Transaction{})
-//
-//	alice, err := skademlia.NewKeys(1, 1)
-//	assert.NoError(t, err)
-//	bob, err := skademlia.NewKeys(1, 1)
-//	assert.NoError(t, err)
-//
-//	aliceID := alice.PublicKey()
-//	bobID := bob.PublicKey()
-//
-//	// Case 1 - Success
-//	WriteAccountBalance(state, aliceID, 1)
-//
-//	tx := AttachSenderToTransaction(alice, NewTransaction(sys.TagTransfer, buildTransferPayload(bobID, 1).Marshal()))
-//	assert.NoError(t, ApplyTransaction(state, &round, &tx))
-//
-//	// Case 2 - Not enough balance
-//	tx = AttachSenderToTransaction(alice, NewTransaction(sys.TagTransfer, buildTransferPayload(bobID, 1).Marshal()))
-//	assert.Error(t, ApplyTransaction(state, &round, &tx))
-//
-//	// Case 3 - Self-transfer without enough balance
-//	tx = AttachSenderToTransaction(alice, NewTransaction(sys.TagTransfer, buildTransferPayload(aliceID, 1).Marshal()))
-//	assert.Error(t, ApplyTransaction(state, &round, &tx))
-//}
-//
-//func TestApplyStakeTransaction(t *testing.T) {
-//	t.Parallel()
-//
-//	state := avl.New(store.NewInmem())
-//	block := NewBlock(0, state.Checksum(), 0, Transaction{}, Transaction{})
-//
-//	account, err := skademlia.NewKeys(1, 1)
-//	assert.NoError(t, err)
-//
-//	accountID := account.PublicKey()
-//
-//	// Case 1 - Placement success
-//	WriteAccountBalance(state, accountID, 100)
-//
-//	tx := AttachSenderToTransaction(account, NewTransaction(sys.TagStake, buildPlaceStakePayload(100).Marshal()))
-//	assert.NoError(t, ApplyTransaction(state, &round, &tx))
-//
-//	// Case 2 - Not enough balance
-//	tx = AttachSenderToTransaction(account, NewTransaction(sys.TagStake, buildPlaceStakePayload(100).Marshal()))
-//	assert.Error(t, ApplyTransaction(state, &round, &tx))
-//
-//	// Case 3 - Withdrawal success
-//	tx = AttachSenderToTransaction(account, NewTransaction(sys.TagStake, buildWithdrawStakePayload(100).Marshal()))
-//	assert.NoError(t, ApplyTransaction(state, &round, &tx))
-//
-//	finalBalance, _ := ReadAccountBalance(state, accountID)
-//	assert.Equal(t, finalBalance, uint64(100))
-//}
-//
-//func TestApplyBatchTransaction(t *testing.T) {
-//	t.Parallel()
-//
-//	state := avl.New(store.NewInmem())
-//	block := NewBlock(0, state.Checksum(), 0, Transaction{}, Transaction{})
-//
-//	alice, err := skademlia.NewKeys(1, 1)
-//	assert.NoError(t, err)
-//	bob, err := skademlia.NewKeys(1, 1)
-//	assert.NoError(t, err)
-//
-//	aliceID := alice.PublicKey()
-//	bobID := bob.PublicKey()
-//
-//	WriteAccountBalance(state, aliceID, 100)
-//
-//	// initial stake
-//	tx := AttachSenderToTransaction(alice, NewTransaction(sys.TagStake, buildPlaceStakePayload(100).Marshal()))
-//	err = ApplyTransaction(state, &round, &tx)
-//	assert.NoError(t, err)
-//
-//	// this implies order
-//	var batch Batch
-//	assert.NoError(t, batch.AddStake(buildWithdrawStakePayload(100)))
-//	assert.NoError(t, batch.AddTransfer(buildTransferPayload(bobID, 100)))
-//
-//	tx = AttachSenderToTransaction(alice, NewTransaction(sys.TagBatch, batch.Marshal()))
-//	assert.NoError(t, ApplyTransaction(state, &round, &tx))
-//
-//	finalBobBalance, _ := ReadAccountBalance(state, bobID)
-//	assert.Equal(t, finalBobBalance, uint64(100))
-//}
-//
-//func TestApplyContractTransaction(t *testing.T) {
-//	t.Parallel()
-//
-//	state := avl.New(store.NewInmem())
-//	block := NewBlock(0, state.Checksum(), 0, Transaction{}, Transaction{})
-//
-//	account, err := skademlia.NewKeys(1, 1)
-//	assert.NoError(t, err)
-//
-//	accountID := account.PublicKey()
-//
-//	code, err := ioutil.ReadFile("testdata/transfer_back.wasm")
-//	assert.NoError(t, err)
-//
-//	// Case 1 - balance < gas_fee
-//	WriteAccountBalance(state, accountID, 99999)
-//	tx := AttachSenderToTransaction(account, NewTransaction(sys.TagContract, buildContractSpawnPayload(100000, 0, code).Marshal()))
-//	assert.Error(t, ApplyTransaction(state, &round, &tx))
-//
-//	// Case 2 - Success
-//	WriteAccountBalance(state, accountID, 100000)
-//	tx = AttachSenderToTransaction(account, NewTransaction(sys.TagContract, buildContractSpawnPayload(100000, 0, code).Marshal()))
-//	assert.NoError(t, ApplyTransaction(state, &round, &tx))
-//
-//	finalBalance, _ := ReadAccountBalance(state, accountID)
-//	assert.Condition(t, func() bool { return finalBalance > 0 && finalBalance < 100000 })
-//
-//	contractID := tx.ID
-//
-//	// Try to deposit gas
-//	WriteAccountBalance(state, accountID, 1000000000)
-//	tx = AttachSenderToTransaction(account, NewTransaction(sys.TagTransfer, buildTransferWithInvocationPayload(contractID, 0, 0, nil, nil, 1337).Marshal()))
-//
-//	assert.NoError(t, ApplyTransaction(state, &round, &tx))
-//
-//	gasDeposit, _ := ReadAccountContractGasBalance(state, contractID)
-//	assert.EqualValues(t, 1337, gasDeposit)
-//
-//	// Try to transfer some money
-//	WriteAccountBalance(state, accountID, 1000000000)
-//	tx = AttachSenderToTransaction(account, NewTransaction(sys.TagTransfer, buildTransferWithInvocationPayload(contractID, 200000000, 500000, []byte("on_money_received"), nil, 0).Marshal()))
-//
-//	assert.NoError(t, ApplyTransaction(state, &round, &tx))
-//
-//	finalBalance, _ = ReadAccountBalance(state, accountID)
-//	assert.True(t, finalBalance > 1000000000-100000000-500000 && finalBalance < 1000000000-100000000)
-//
-//	// Try to invoke with contract gas balance
-//	WriteAccountBalance(state, accountID, 200000000)
-//	WriteAccountContractGasBalance(state, contractID, 1000000000)
-//
-//	tx = AttachSenderToTransaction(account, NewTransaction(sys.TagTransfer, buildTransferWithInvocationPayload(contractID, 200000000, 500000, []byte("on_money_received"), nil, 0).Marshal()))
-//	assert.NoError(t, ApplyTransaction(state, &round, &tx))
-//
-//	finalBalance, _ = ReadAccountBalance(state, accountID)
-//	assert.Equal(t, uint64(100000000), finalBalance)
-//	finalGasBalance, _ := ReadAccountContractGasBalance(state, contractID)
-//	assert.True(t, finalGasBalance > 0 && finalGasBalance < 1000000000)
-//
-//	// Try to invoke with both balances
-//	WriteAccountBalance(state, accountID, 300000000)
-//	WriteAccountContractGasBalance(state, contractID, 10)
-//
-//	tx = AttachSenderToTransaction(account, NewTransaction(sys.TagTransfer, buildTransferWithInvocationPayload(contractID, 200000000, 500000, []byte("on_money_received"), nil, 0).Marshal()))
-//	assert.NoError(t, ApplyTransaction(state, &round, &tx))
-//
-//	finalBalance, _ = ReadAccountBalance(state, accountID)
-//	assert.True(t, finalBalance > 200000000-500000 && finalBalance < 200000000)
-//	finalGasBalance, _ = ReadAccountContractGasBalance(state, contractID)
-//	assert.Equal(t, finalGasBalance, uint64(0))
-//
-//	// Now it should fail
-//	WriteAccountBalance(state, accountID, 200000000)
-//	WriteAccountContractGasBalance(state, contractID, 0)
-//
-//	tx = AttachSenderToTransaction(account, NewTransaction(sys.TagTransfer, buildTransferWithInvocationPayload(contractID, 200000000, 500000, []byte("on_money_received"), nil, 0).Marshal()))
-//	assert.Error(t, ApplyTransaction(state, &round, &tx))
-//
-//	code, err = ioutil.ReadFile("testdata/recursive_invocation.wasm")
-//	assert.NoError(t, err)
-//
-//	WriteAccountBalance(state, accountID, 100000000)
-//	tx = AttachSenderToTransaction(account, NewTransaction(sys.TagContract, buildContractSpawnPayload(100000, 0, code).Marshal()))
-//	assert.NoError(t, ApplyTransaction(state, &round, &tx))
-//
-//	recursiveInvocationContractID := tx.ID
-//
-//	WriteAccountBalance(state, accountID, 6000000)
-//	tx = AttachSenderToTransaction(account, NewTransaction(sys.TagTransfer, buildTransferWithInvocationPayload(recursiveInvocationContractID, 0, 5000000, []byte("bomb"), recursiveInvocationContractID[:], 0).Marshal()))
-//	assert.NoError(t, ApplyTransaction(state, &round, &tx))
-//
-//	finalBalance, _ = ReadAccountBalance(state, accountID)
-//	assert.True(t, finalBalance >= 1000000 && finalBalance < 2000000) // GasLimit specified in contract is 1000000
-//}
-//
-//func buildTransferWithInvocationPayload(dest AccountID, amount uint64, gasLimit uint64, funcName []byte, param []byte, gasDeposit uint64) Transfer {
-//
-//	return Transfer{
-//		Recipient:  dest,
-//		Amount:     amount,
-//		GasLimit:   gasLimit,
-//		GasDeposit: gasDeposit,
-//		FuncName:   funcName,
-//		FuncParams: param,
-//	}
-//}
-//
-//func buildContractSpawnPayload(gasLimit, gasDeposit uint64, code []byte) Contract {
-//	return Contract{
-//		GasLimit:   gasLimit,
-//		GasDeposit: gasDeposit,
-//		Code:       code,
-//	}
-//}
-//
-//func buildTransferPayload(dest AccountID, amount uint64) Transfer {
-//	return Transfer{
-//		Recipient: dest,
-//		Amount:    amount,
-//	}
-//}
-//
-//func buildPlaceStakePayload(amount uint64) Stake {
-//	return Stake{
-//		Opcode: sys.PlaceStake,
-//		Amount: amount,
-//	}
-//}
-//
-//func buildWithdrawStakePayload(amount uint64) Stake {
-//	return Stake{
-//		Opcode: sys.WithdrawStake,
-//		Amount: amount,
-//	}
-//}
+import (
+	"encoding/binary"
+	"io/ioutil"
+	"math/rand"
+	"sync/atomic"
+	"testing"
+
+	"github.com/perlin-network/noise/edwards25519"
+	"github.com/perlin-network/noise/skademlia"
+	"github.com/perlin-network/wavelet/avl"
+	"github.com/perlin-network/wavelet/store"
+	"github.com/perlin-network/wavelet/sys"
+	"github.com/stretchr/testify/assert"
+)
+
+type testAccount struct {
+	keys   *skademlia.Keypair
+	effect struct {
+		Balance uint64
+		Stake   uint64
+	}
+}
+
+func TestApplyTransaction_Single(t *testing.T) {
+	t.Parallel()
+
+	const InitialBalance = 100000000
+
+	state := avl.New(store.NewInmem())
+
+	viewID := uint64(0)
+	state.SetViewID(viewID)
+
+	accounts := make(map[AccountID]*testAccount)
+	accountIDs := make([]AccountID, 0)
+
+	for i := 0; i < 60; i++ {
+		keys, err := skademlia.NewKeys(1, 1)
+		assert.NoError(t, err)
+		account := &testAccount{
+			keys: keys,
+		}
+
+		WriteAccountBalance(state, keys.PublicKey(), InitialBalance)
+		account.effect.Balance = InitialBalance
+
+		accounts[keys.PublicKey()] = account
+		accountIDs = append(accountIDs, keys.PublicKey())
+	}
+
+	rng := rand.New(rand.NewSource(42))
+
+	block := NewBlock(viewID, state.Checksum())
+	var nonce uint64
+
+	for i := 0; i < 10000; i++ {
+		switch rng.Intn(2) {
+		case 0:
+			amount := rng.Uint64()%100 + 1
+
+			account := accounts[accountIDs[rng.Intn(len(accountIDs))]]
+			account.effect.Stake += amount
+			account.effect.Balance -= amount
+
+			tx := buildSignedTransaction(
+				account.keys, sys.TagStake,
+				atomic.AddUint64(&nonce, 1), block.Index+1,
+				buildPlaceStakePayload(amount).Marshal(),
+			)
+
+			assert.NoError(t, ApplyTransaction(state, &block, &tx))
+
+		case 1:
+			amount := rng.Uint64()%100 + 1
+
+			fromAccount := accounts[accountIDs[rng.Intn(len(accountIDs))]]
+			toAccount := accounts[accountIDs[rng.Intn(len(accountIDs))]]
+
+			if fromAccount.keys.PublicKey() == toAccount.keys.PublicKey() {
+				continue
+			}
+
+			toAccountID := toAccount.keys.PublicKey()
+
+			fromAccount.effect.Balance -= amount
+			toAccount.effect.Balance += amount
+
+			tx := buildSignedTransaction(
+				fromAccount.keys, sys.TagTransfer,
+				atomic.AddUint64(&nonce, 1), block.Index+1,
+				buildTransferPayload(toAccountID, amount).Marshal(),
+			)
+
+			assert.NoError(t, ApplyTransaction(state, &block, &tx))
+
+		default:
+			panic("unreachable")
+		}
+	}
+
+	for id, account := range accounts {
+		stake, _ := ReadAccountStake(state, id)
+		assert.Equal(t, stake, account.effect.Stake)
+
+		balance, _ := ReadAccountBalance(state, id)
+		assert.Equal(t, balance, account.effect.Balance)
+	}
+}
+
+func TestApplyTransferTransaction(t *testing.T) {
+	t.Parallel()
+
+	state := avl.New(store.NewInmem())
+	block := NewBlock(0, state.Checksum())
+
+	alice, err := skademlia.NewKeys(1, 1)
+	assert.NoError(t, err)
+	bob, err := skademlia.NewKeys(1, 1)
+	assert.NoError(t, err)
+
+	aliceID := alice.PublicKey()
+	bobID := bob.PublicKey()
+
+	var nonce uint64
+
+	// Case 1 - Success
+	WriteAccountBalance(state, aliceID, 1)
+
+	tx := buildSignedTransaction(
+		alice, sys.TagTransfer,
+		atomic.AddUint64(&nonce, 1), block.Index+1,
+		buildTransferPayload(bobID, 1).Marshal(),
+	)
+	assert.NoError(t, ApplyTransaction(state, &block, &tx))
+
+	// Case 2 - Not enough balance
+	tx = buildSignedTransaction(
+		alice, sys.TagTransfer,
+		atomic.AddUint64(&nonce, 1), block.Index+1,
+		buildTransferPayload(bobID, 1).Marshal(),
+	)
+	assert.Error(t, ApplyTransaction(state, &block, &tx))
+
+	// Case 3 - Self-transfer without enough balance
+	tx = buildSignedTransaction(
+		alice, sys.TagTransfer,
+		atomic.AddUint64(&nonce, 1), block.Index+1,
+		buildTransferPayload(aliceID, 1).Marshal(),
+	)
+	assert.Error(t, ApplyTransaction(state, &block, &tx))
+}
+
+func TestApplyStakeTransaction(t *testing.T) {
+	t.Parallel()
+
+	state := avl.New(store.NewInmem())
+	block := NewBlock(0, state.Checksum())
+
+	account, err := skademlia.NewKeys(1, 1)
+	assert.NoError(t, err)
+
+	accountID := account.PublicKey()
+	var nonce uint64
+
+	// Case 1 - Placement success
+	WriteAccountBalance(state, accountID, 100)
+
+	tx := buildSignedTransaction(
+		account, sys.TagStake,
+		atomic.AddUint64(&nonce, 1), block.Index+1,
+		buildPlaceStakePayload(100).Marshal(),
+	)
+	assert.NoError(t, ApplyTransaction(state, &block, &tx))
+
+	// Case 2 - Not enough balance
+	tx = buildSignedTransaction(
+		account, sys.TagStake,
+		atomic.AddUint64(&nonce, 1), block.Index+1,
+		buildPlaceStakePayload(100).Marshal(),
+	)
+	assert.Error(t, ApplyTransaction(state, &block, &tx))
+
+	// Case 3 - Withdrawal success
+	tx = buildSignedTransaction(
+		account, sys.TagStake,
+		atomic.AddUint64(&nonce, 1), block.Index+1,
+		buildWithdrawStakePayload(100).Marshal(),
+	)
+	assert.NoError(t, ApplyTransaction(state, &block, &tx))
+
+	finalBalance, _ := ReadAccountBalance(state, accountID)
+	assert.Equal(t, finalBalance, uint64(100))
+}
+
+func TestApplyBatchTransaction(t *testing.T) {
+	t.Parallel()
+
+	state := avl.New(store.NewInmem())
+	block := NewBlock(0, state.Checksum())
+
+	alice, err := skademlia.NewKeys(1, 1)
+	assert.NoError(t, err)
+	bob, err := skademlia.NewKeys(1, 1)
+	assert.NoError(t, err)
+
+	aliceID := alice.PublicKey()
+	bobID := bob.PublicKey()
+	var nonce uint64
+
+	WriteAccountBalance(state, aliceID, 100)
+
+	// initial stake
+	tx := buildSignedTransaction(
+		alice, sys.TagStake,
+		atomic.AddUint64(&nonce, 1), block.Index+1,
+		buildPlaceStakePayload(100).Marshal(),
+	)
+	err = ApplyTransaction(state, &block, &tx)
+	assert.NoError(t, err)
+
+	// this implies order
+	var batch Batch
+	assert.NoError(t, batch.AddStake(buildWithdrawStakePayload(100)))
+	assert.NoError(t, batch.AddTransfer(buildTransferPayload(bobID, 100)))
+
+	tx = buildSignedTransaction(
+		alice, sys.TagBatch,
+		atomic.AddUint64(&nonce, 1), block.Index+1,
+		batch.Marshal(),
+	)
+	assert.NoError(t, ApplyTransaction(state, &block, &tx))
+
+	finalBobBalance, _ := ReadAccountBalance(state, bobID)
+	assert.Equal(t, finalBobBalance, uint64(100))
+}
+
+func TestApplyContractTransaction(t *testing.T) {
+	t.Parallel()
+
+	state := avl.New(store.NewInmem())
+	block := NewBlock(0, state.Checksum())
+
+	account, err := skademlia.NewKeys(1, 1)
+	assert.NoError(t, err)
+
+	accountID := account.PublicKey()
+	var nonce uint64
+
+	code, err := ioutil.ReadFile("testdata/transfer_back.wasm")
+	assert.NoError(t, err)
+
+	// Case 1 - balance < gas_fee
+	WriteAccountBalance(state, accountID, 99999)
+	tx := buildSignedTransaction(
+		account, sys.TagContract,
+		atomic.AddUint64(&nonce, 1), block.Index+1,
+		buildContractSpawnPayload(100000, 0, code).Marshal(),
+	)
+	assert.Error(t, ApplyTransaction(state, &block, &tx))
+
+	// Case 2 - Success
+	WriteAccountBalance(state, accountID, 100000)
+	tx = buildSignedTransaction(
+		account, sys.TagContract,
+		atomic.AddUint64(&nonce, 1), block.Index+1,
+		buildContractSpawnPayload(100000, 0, code).Marshal(),
+	)
+	assert.NoError(t, ApplyTransaction(state, &block, &tx))
+
+	finalBalance, _ := ReadAccountBalance(state, accountID)
+	assert.Condition(t, func() bool { return finalBalance > 0 && finalBalance < 100000 })
+
+	contractID := tx.ID
+
+	// Try to deposit gas
+	WriteAccountBalance(state, accountID, 1000000000)
+	tx = buildSignedTransaction(
+		account, sys.TagTransfer,
+		atomic.AddUint64(&nonce, 1), block.Index+1,
+		buildTransferWithInvocationPayload(contractID, 0, 0, nil, nil, 1337).Marshal(),
+	)
+
+	assert.NoError(t, ApplyTransaction(state, &block, &tx))
+
+	gasDeposit, _ := ReadAccountContractGasBalance(state, contractID)
+	assert.EqualValues(t, 1337, gasDeposit)
+
+	// Try to transfer some money
+	WriteAccountBalance(state, accountID, 1000000000)
+	tx = buildSignedTransaction(
+		account, sys.TagTransfer,
+		atomic.AddUint64(&nonce, 1), block.Index+1,
+		buildTransferWithInvocationPayload(contractID, 200000000, 500000, []byte("on_money_received"), nil, 0).Marshal(),
+	)
+
+	assert.NoError(t, ApplyTransaction(state, &block, &tx))
+
+	finalBalance, _ = ReadAccountBalance(state, accountID)
+	assert.True(t, finalBalance > 1000000000-100000000-500000 && finalBalance < 1000000000-100000000)
+
+	// Try to invoke with contract gas balance
+	WriteAccountBalance(state, accountID, 200000000)
+	WriteAccountContractGasBalance(state, contractID, 1000000000)
+
+	tx = buildSignedTransaction(
+		account, sys.TagTransfer,
+		atomic.AddUint64(&nonce, 1), block.Index+1,
+		buildTransferWithInvocationPayload(contractID, 200000000, 500000, []byte("on_money_received"), nil, 0).Marshal(),
+	)
+	assert.NoError(t, ApplyTransaction(state, &block, &tx))
+
+	finalBalance, _ = ReadAccountBalance(state, accountID)
+	assert.Equal(t, uint64(100000000), finalBalance)
+	finalGasBalance, _ := ReadAccountContractGasBalance(state, contractID)
+	assert.True(t, finalGasBalance > 0 && finalGasBalance < 1000000000)
+
+	// Try to invoke with both balances
+	WriteAccountBalance(state, accountID, 300000000)
+	WriteAccountContractGasBalance(state, contractID, 10)
+
+	tx = buildSignedTransaction(
+		account, sys.TagTransfer,
+		atomic.AddUint64(&nonce, 1), block.Index+1,
+		buildTransferWithInvocationPayload(contractID, 200000000, 500000, []byte("on_money_received"), nil, 0).Marshal(),
+	)
+	assert.NoError(t, ApplyTransaction(state, &block, &tx))
+
+	finalBalance, _ = ReadAccountBalance(state, accountID)
+	assert.True(t, finalBalance > 200000000-500000 && finalBalance < 200000000)
+	finalGasBalance, _ = ReadAccountContractGasBalance(state, contractID)
+	assert.Equal(t, finalGasBalance, uint64(0))
+
+	// Now it should fail
+	WriteAccountBalance(state, accountID, 200000000)
+	WriteAccountContractGasBalance(state, contractID, 0)
+
+	tx = buildSignedTransaction(
+		account, sys.TagTransfer,
+		atomic.AddUint64(&nonce, 1), block.Index+1,
+		buildTransferWithInvocationPayload(contractID, 200000000, 500000, []byte("on_money_received"), nil, 0).Marshal(),
+	)
+	assert.Error(t, ApplyTransaction(state, &block, &tx))
+
+	code, err = ioutil.ReadFile("testdata/recursive_invocation.wasm")
+	assert.NoError(t, err)
+
+	WriteAccountBalance(state, accountID, 100000000)
+	tx = buildSignedTransaction(
+		account, sys.TagContract,
+		atomic.AddUint64(&nonce, 1), block.Index+1,
+		buildContractSpawnPayload(100000, 0, code).Marshal(),
+	)
+	assert.NoError(t, ApplyTransaction(state, &block, &tx))
+
+	recursiveInvocationContractID := tx.ID
+
+	WriteAccountBalance(state, accountID, 6000000)
+	tx = buildSignedTransaction(
+		account, sys.TagTransfer,
+		atomic.AddUint64(&nonce, 1), block.Index+1,
+		buildTransferWithInvocationPayload(recursiveInvocationContractID, 0, 5000000, []byte("bomb"), recursiveInvocationContractID[:], 0).Marshal(),
+	)
+	assert.NoError(t, ApplyTransaction(state, &block, &tx))
+
+	finalBalance, _ = ReadAccountBalance(state, accountID)
+	assert.True(t, finalBalance >= 1000000 && finalBalance < 2000000) // GasLimit specified in contract is 1000000
+}
+
+func buildTransferWithInvocationPayload(dest AccountID, amount uint64, gasLimit uint64, funcName []byte, param []byte, gasDeposit uint64) Transfer {
+
+	return Transfer{
+		Recipient:  dest,
+		Amount:     amount,
+		GasLimit:   gasLimit,
+		GasDeposit: gasDeposit,
+		FuncName:   funcName,
+		FuncParams: param,
+	}
+}
+
+func buildContractSpawnPayload(gasLimit, gasDeposit uint64, code []byte) Contract {
+	return Contract{
+		GasLimit:   gasLimit,
+		GasDeposit: gasDeposit,
+		Code:       code,
+	}
+}
+
+func buildTransferPayload(dest AccountID, amount uint64) Transfer {
+	return Transfer{
+		Recipient: dest,
+		Amount:    amount,
+	}
+}
+
+func buildPlaceStakePayload(amount uint64) Stake {
+	return Stake{
+		Opcode: sys.PlaceStake,
+		Amount: amount,
+	}
+}
+
+func buildWithdrawStakePayload(amount uint64) Stake {
+	return Stake{
+		Opcode: sys.WithdrawStake,
+		Amount: amount,
+	}
+}
+
+func buildSignedTransaction(keys *skademlia.Keypair, tag sys.Tag, nonce uint64, block uint64, payload []byte) Transaction {
+	var nonceBuf [8]byte
+	binary.BigEndian.PutUint64(nonceBuf[:], nonce)
+
+	var blockBuf [8]byte
+	binary.BigEndian.PutUint64(blockBuf[:], block)
+
+	signature := edwards25519.Sign(
+		keys.PrivateKey(),
+		append(nonceBuf[:], append(blockBuf[:], append([]byte{byte(tag)}, payload...)...)...),
+	)
+
+	return NewSignedTransaction(
+		keys.PublicKey(), nonce, block,
+		tag, payload, signature,
+	)
+}


### PR DESCRIPTION
This PR re-adds the following tests that have been commented out to speed up implementation of himitsu:

- [x] High-level ledger tests (`ledger_test.go`)
- [x] Tx applier tests (`tx_applier_test.go`)

Make sure PR #315 is merged first before merging this PR.