### PR TITLE
Limit transactions within the block.

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -43,6 +43,9 @@ type config struct {
 	// Number of blocks after which transactions will be pruned from the graph
 	pruningLimit uint8
 
+	// Max number of transactions within the block
+	blockTxLimit uint64
+
 	// shared secret for http api authorization
 	secret string
 }
@@ -80,6 +83,8 @@ func defaultConfig() config {
 		bloomFilterK: 3,
 
 		pruningLimit: 30,
+
+		blockTxLimit: 1 << 16,
 	}
 
 	switch sys.VersionMeta {
@@ -204,6 +209,12 @@ func WithTXSyncChunkSize(n uint64) Option {
 func WithTXSyncLimit(n uint64) Option {
 	return func(c *config) {
 		c.txSyncLimit = n
+	}
+}
+
+func WithBlockTXLimit(n uint64) Option {
+	return func(c *config) {
+		c.blockTxLimit = n
 	}
 }
 
@@ -354,6 +365,14 @@ func GetTXSyncChunkSize() uint64 {
 func GetTXSyncLimit() uint64 {
 	l.RLock()
 	t := c.txSyncLimit
+	l.RUnlock()
+
+	return t
+}
+
+func GetBlockTXLimit() uint64 {
+	l.RLock()
+	t := c.blockTxLimit
 	l.RUnlock()
 
 	return t

--- a/transactions.go
+++ b/transactions.go
@@ -268,14 +268,19 @@ func (t *Transactions) ProposableIDs() []TransactionID {
 	t.RLock()
 	defer t.RUnlock()
 
-	proposable := make([]TransactionID, 0, t.index.Len())
+	limit := int(conf.GetBlockTXLimit())
+	if t.index.Len() < limit {
+		limit = t.index.Len()
+	}
+
+	proposable := make([]TransactionID, 0, limit)
 
 	t.index.Ascend(func(i btree.Item) bool {
 		if t.buffer[i.(mempoolItem).id].Block <= t.height+1 {
 			proposable = append(proposable, i.(mempoolItem).id)
 		}
 
-		return true
+		return len(proposable) < limit
 	})
 
 	return proposable


### PR DESCRIPTION
In order to not get block so big, that it will be impossible to send it over grpc, add limit to transactions number within the block.