### PR TITLE
Revert "block: use buffer pool for marshaling block (#322)"

### DIFF
--- a/block.go
+++ b/block.go
@@ -1,10 +1,10 @@
 package wavelet
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"github.com/valyala/bytebufferpool"
 	"io"
 
 	"github.com/pkg/errors"
@@ -36,8 +36,7 @@ func (b *Block) GetID() string {
 }
 
 func (b Block) Marshal() []byte {
-	buf := bytebufferpool.Get()
-	defer bytebufferpool.Put(buf)
+	buf := bytes.NewBuffer(make([]byte, 0, 8+SizeMerkleNodeID+4+4+len(b.Transactions)*SizeTransactionID))
 
 	binary.Write(buf, binary.BigEndian, b.Index)
 	buf.Write(b.Merkle[:])


### PR DESCRIPTION
It was my mistake to use bytebuffer in the first place, since we leak slice from marshaling call, which makes access to same slice (same buffer) from different places.
Ideally we should put buffer back after we done with marshalled block, but we do not know where exactly it happens.

This caused a lot of race condition warnings