### PR TITLE
WCTL: Fix Find method returned a Transaction when the ID is actually a Contract

### DIFF
--- a/wctl/tx_find.go
+++ b/wctl/tx_find.go
@@ -5,18 +5,16 @@ import "errors"
 // Find queries for either Account or Transaction. Either would be nil. If an
 // error occurs, both will be nil.
 func (c *Client) Find(address [32]byte) (*Account, *Transaction, error) {
+	a, err := c.GetAccount(address)
+	if err == nil {
+		if a.Balance > 0 || a.Stake > 0 || a.Nonce > 0 || a.IsContract || a.NumPages > 0 {
+			return a, nil, nil
+		}
+	}
+
 	t, err := c.GetTransaction(address)
 	if err == nil {
 		return nil, t, nil
-	}
-
-	a, err := c.GetAccount(address)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if a.Balance > 0 || a.Stake > 0 || a.Nonce > 0 || a.IsContract || a.NumPages > 0 {
-		return a, nil, nil
 	}
 
 	// return nil, nil, err


### PR DESCRIPTION
The bug is because, for Contract, we use the Transaction ID as its ID.
So, we need to check for account first, before transaction.