### PR TITLE
Update noise

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/minio/highwayhash v1.0.0
 	github.com/perlin-network/life v0.0.0-20190723115110-3091ed0c1be8
-	github.com/perlin-network/noise v1.1.1-0.20191106061607-bf3f562fb797
+	github.com/perlin-network/noise v1.1.1-0.20191111043414-58046b382f54
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/perlin-network/noise v1.1.1-0.20191023080233-724c7cf9f251 h1:jIqtLD+n
 github.com/perlin-network/noise v1.1.1-0.20191023080233-724c7cf9f251/go.mod h1:gtq69gqAZNXmk+lXhx7frAEbYBzPlrfaqscOoMSIFWE=
 github.com/perlin-network/noise v1.1.1-0.20191106061607-bf3f562fb797 h1:qwugaZDa3BEIe8i2SkgTI+2H2f6ZcSFJ57L7jQ8fEoc=
 github.com/perlin-network/noise v1.1.1-0.20191106061607-bf3f562fb797/go.mod h1:gtq69gqAZNXmk+lXhx7frAEbYBzPlrfaqscOoMSIFWE=
+github.com/perlin-network/noise v1.1.1-0.20191111043414-58046b382f54 h1:rbs2U9KP4o5fiuTSeFKf5VACAWck8exgKsdVC7YoN8U=
+github.com/perlin-network/noise v1.1.1-0.20191111043414-58046b382f54/go.mod h1:gtq69gqAZNXmk+lXhx7frAEbYBzPlrfaqscOoMSIFWE=
 github.com/perlin-network/wagon v0.3.1-0.20180825141017-f8cb99b55a39 h1:CYHXy6CWxxL7ugjvCbTELOm2j5iRLEWGPl3AQYvretw=
 github.com/perlin-network/wagon v0.3.1-0.20180825141017-f8cb99b55a39/go.mod h1:zHOMvbitcZek8oshsMO5VpyBjWjV9X8cn8WTZwdebpM=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 h1:JhzVVoYvbOACxoUmOs6V/G4D5nPVUW73rKvXxP4XUJc=


### PR DESCRIPTION
Updates noise to commit https://github.com/perlin-network/noise/commit/58046b3, which includes PR https://github.com/perlin-network/noise/pull/256 that is required to run Wavelet on Raspberry pi.