### PR TITLE
Use In-Memory KV database

### DIFF
--- a/cmd/wavelet/node/node.go
+++ b/cmd/wavelet/node/node.go
@@ -173,10 +173,14 @@ func New(cfg *Config) (*Wavelet, error) {
 
 	w.Net = client
 
-	kv, err := store.NewLevelDB(cfg.Database)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"Failed to create/open database located at %s", cfg.Database)
+	var kv store.KV
+	if len(cfg.Database) == 0 {
+		kv = store.NewInmem()
+	} else {
+		if kv, err = store.NewLevelDB(cfg.Database); err != nil {
+			return nil, fmt.Errorf(
+				"Failed to create/open database located at %s", cfg.Database)
+		}
 	}
 
 	w.db = kv

--- a/store/inmem.go
+++ b/store/inmem.go
@@ -37,8 +37,16 @@ type inmemWriteBatch struct {
 	pairs []kvPair
 }
 
+// It is safe to modify the contents of the argument after Put returns but not
+// before.
 func (b *inmemWriteBatch) Put(key, value []byte) error {
-	b.pairs = append(b.pairs, kvPair{key: key, value: value})
+	keyCopy := make([]byte, len(key))
+	copy(keyCopy, key)
+
+	valueCopy := make([]byte, len(value))
+	copy(valueCopy, value)
+
+	b.pairs = append(b.pairs, kvPair{key: keyCopy, value: valueCopy})
 	return nil
 }
 
@@ -75,18 +83,32 @@ func (s *inmemKV) Close() error {
 	return nil
 }
 
-func (s *inmemKV) Get(key []byte) ([]byte, error) {
-	s.RLock()
-	defer s.RUnlock()
-
-	buf, found := s.db.GetValue(key)
+func (s *inmemKV) get(key []byte) ([]byte, error) {
+	v, found := s.db.GetValue(key)
 	if !found {
 		return nil, errors.New("key not found")
 	}
 
-	return buf.([]byte), nil
+	src := v.([]byte)
+	dest := make([]byte, len(src))
+	copy(dest, src)
+
+	return dest, nil
 }
 
+// The returned slice is its own copy, it is safe to modify the contents
+// of the returned slice.
+// It is safe to modify the contents of the argument after Get returns.
+func (s *inmemKV) Get(key []byte) ([]byte, error) {
+	s.RLock()
+	defer s.RUnlock()
+
+	return s.get(key)
+}
+
+// The returned slice is its own copy, it is safe to modify the contents
+// of the returned slice.
+// It is safe to modify the contents of the argument after Get returns.
 func (s *inmemKV) MultiGet(keys ...[]byte) ([][]byte, error) {
 	s.RLock()
 	defer s.RUnlock()
@@ -94,22 +116,30 @@ func (s *inmemKV) MultiGet(keys ...[]byte) ([][]byte, error) {
 	var bufs [][]byte
 
 	for _, key := range keys {
-		buf, found := s.db.GetValue(key)
-		if !found {
-			return nil, errors.New("key not found")
+		buf, err := s.get(key)
+		if err != nil {
+			return nil, err
 		}
 
-		bufs = append(bufs, buf.([]byte))
+		bufs = append(bufs, buf)
 	}
 
 	return bufs, nil
 }
 
+// It is safe to modify the contents of the arguments after Put returns but not
+// before.
 func (s *inmemKV) Put(key, value []byte) error {
 	s.Lock()
 	defer s.Unlock()
 
-	_ = s.db.Set(key, value)
+	keyCopy := make([]byte, len(key))
+	copy(keyCopy, key)
+
+	valueCopy := make([]byte, len(value))
+	copy(valueCopy, value)
+
+	_ = s.db.Set(keyCopy, valueCopy)
 	return nil
 }
 
@@ -141,6 +171,8 @@ func (s *inmemKV) CommitWriteBatch(batch WriteBatch) error {
 	return errors.New("inmem: not fed in a proper in-memory write batch")
 }
 
+// It is safe to modify the contents of the arguments after Delete returns but
+// not before.
 func (s *inmemKV) Delete(key []byte) error {
 	s.Lock()
 	defer s.Unlock()


### PR DESCRIPTION
Currently, in case of the database directory is empty, we will use the LevelDB's In-Memory storage.
We have our own In-Memory KV implementation, and by using LevelDb's In-Memory storage, it makes it harder to change database.

I guess the main reason we don't use own In-Memory KV, is because it does not work because of bugs.

This PR fixes the In-Memory KV bugs and use it in case when database directory is empty.