### PR TITLE
Enable collapseTransactions log

### DIFF
--- a/cmd/wavelet/events.go
+++ b/cmd/wavelet/events.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+
 	"github.com/perlin-network/wavelet/log"
 	"github.com/perlin-network/wavelet/wctl"
 )
@@ -90,8 +91,6 @@ func onTxApplied(u wctl.TxApplied) {
 	logger.Info().
 		Hex("tx_id", u.TxID[:]).
 		Hex("sender_id", u.SenderID[:]).
-		Hex("creator_id", u.CreatorID[:]).
-		Uint64("depth", u.Depth).
 		Uint8("tag", u.Tag).
 		Msg("Transaction applied.")
 	*/
@@ -106,8 +105,6 @@ func onTxFailed(u wctl.TxFailed) {
 	logger.Err(errors.New(u.Error)).
 		Hex("tx_id", u.TxID[:]).
 		Hex("sender_id", u.SenderID[:]).
-		Hex("creator_id", u.CreatorID[:]).
-		Uint64("depth", u.Depth).
 		Uint8("tag", u.Tag).
 		Msg("Transaction failed.")
 }

--- a/ledger.go
+++ b/ledger.go
@@ -1480,7 +1480,7 @@ func (l *Ledger) collapseTransactions(block *Block, logging bool) (*collapseResu
 		collapseState.results, collapseState.err = collapseTransactions(txs, block, l.accounts)
 	})
 
-	if logging {
+	if logging && collapseState.results != nil {
 		for _, tx := range collapseState.results.applied {
 			logEventTX("applied", tx)
 		}

--- a/ledger.go
+++ b/ledger.go
@@ -700,7 +700,7 @@ func (l *Ledger) finalize(block Block) {
 
 	logger := log.Consensus("finalized")
 
-	results, err := l.collapseTransactions(&block, false)
+	results, err := l.collapseTransactions(&block, true)
 	if err != nil {
 		logger := log.Node()
 		logger.Error().

--- a/tx_applier.go
+++ b/tx_applier.go
@@ -339,7 +339,6 @@ func executeContractInTransactionContext(
 		state.GasLimit -= executor.Gas
 
 		//logger.Info().
-		//	Hex("sender_id", tx.Creator[:]).
 		//	Uint64("gas", executor.Gas).
 		//	Uint64("gas_limit", realGasLimit).
 		//	Msg("Deducted PERLs for invoking smart contract function.")

--- a/wctl/tx.go
+++ b/wctl/tx.go
@@ -25,12 +25,11 @@ var (
 )
 
 type TransactionEvent struct {
-	Event  string    `json:"event"`
-	ID     [32]byte  `json:"tx_id"`
-	Sender [32]byte  `json:"sender_id"`
-	Depth  uint64    `json:"depth"`
-	Tag    byte      `json:"tag"`
-	Time   time.Time `json:"time"`
+	Event string    `json:"event"`
+	ID    [32]byte  `json:"tx_id"`
+	Depth uint64    `json:"depth"`
+	Tag   byte      `json:"tag"`
+	Time  time.Time `json:"time"`
 }
 
 // ListTransactions calls the /tx endpoint of the API to list all transactions.
@@ -130,7 +129,6 @@ type Transaction struct {
 	Sender    [32]byte `json:"sender"`
 	Status    string   `json:"status"`
 	Nonce     uint64   `json:"nonce"`
-	Depth     uint64   `json:"depth"`
 	Tag       byte     `json:"tag"`
 	Payload   []byte   `json:"payload"`
 	Signature [64]byte `json:"signature"`
@@ -158,7 +156,6 @@ func (t *Transaction) ParseJSON(v *fastjson.Value) error {
 
 	t.Status = string(v.GetStringBytes("status"))
 	t.Nonce = v.GetUint64("nonce")
-	t.Depth = v.GetUint64("depth")
 	t.Tag = byte(v.GetUint("tag"))
 	t.Payload = v.GetStringBytes("payload")
 

--- a/wctl/ws_callbacks.go
+++ b/wctl/ws_callbacks.go
@@ -123,8 +123,6 @@ type (
 	TxApplied struct {
 		TxID      [32]byte  `json:"tx_id"`
 		SenderID  [32]byte  `json:"sender_id"`
-		CreatorID [32]byte  `json:"creator_id"`
-		Depth     uint64    `json:"depth"`
 		Tag       byte      `json:"tag"`
 		Time      time.Time `json:"time"`
 	}
@@ -140,8 +138,6 @@ type (
 	TxFailed struct {
 		TxID      [32]byte  `json:"tx_id"`
 		SenderID  [32]byte  `json:"sender_id"`
-		CreatorID [32]byte  `json:"creator_id"`
-		Depth     uint64    `json:"depth"`
 		Tag       byte      `json:"tag"`
 		Error     string    `json:"error"`
 		Time      time.Time `json:"time"`

--- a/wctl/ws_callbacks.go
+++ b/wctl/ws_callbacks.go
@@ -121,10 +121,10 @@ type (
 // Mod: tx
 type (
 	TxApplied struct {
-		TxID      [32]byte  `json:"tx_id"`
-		SenderID  [32]byte  `json:"sender_id"`
-		Tag       byte      `json:"tag"`
-		Time      time.Time `json:"time"`
+		TxID     [32]byte  `json:"tx_id"`
+		SenderID [32]byte  `json:"sender_id"`
+		Tag      byte      `json:"tag"`
+		Time     time.Time `json:"time"`
 	}
 	OnTxApplied = func(TxApplied)
 
@@ -136,11 +136,11 @@ type (
 	OnTxGossipError = func(TxGossipError)
 
 	TxFailed struct {
-		TxID      [32]byte  `json:"tx_id"`
-		SenderID  [32]byte  `json:"sender_id"`
-		Tag       byte      `json:"tag"`
-		Error     string    `json:"error"`
-		Time      time.Time `json:"time"`
+		TxID     [32]byte  `json:"tx_id"`
+		SenderID [32]byte  `json:"sender_id"`
+		Tag      byte      `json:"tag"`
+		Error    string    `json:"error"`
+		Time     time.Time `json:"time"`
 	}
 	OnTxFailed = func(TxFailed)
 )

--- a/wctl/ws_tx.go
+++ b/wctl/ws_tx.go
@@ -51,11 +51,6 @@ func parseTxApplied(c *Client, v *fastjson.Value) error {
 		return err
 	}
 
-	if err := jsonHex(v, t.CreatorID[:], "creator_id"); err != nil {
-		return err
-	}
-
-	t.Depth = v.GetUint64("depth")
 	t.Tag = byte(v.GetUint("tag"))
 
 	if err := jsonTime(v, &t.Time, "time"); err != nil {
@@ -97,11 +92,6 @@ func parseTxFailed(c *Client, v *fastjson.Value) error {
 		return err
 	}
 
-	if err := jsonHex(v, t.CreatorID[:], "creator_id"); err != nil {
-		return err
-	}
-
-	t.Depth = v.GetUint64("depth")
 	t.Tag = byte(v.GetUint("tag"))
 	t.Error = jsonString(v, "error")
 


### PR DESCRIPTION
This PR enables collapseTransactions log. For some reason it's disabled.

Also, this PR fixes a potential panic in collapseTransactions and removes unused fields in wctl.