### PR TITLE
Merge coverage result from multiple test runs

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Concat coverage
         run: |
-        echo "mode: atomic" > coverage.txt
-        grep -h -v "mode: atomic" coverage_*.txt >> coverage.txt
+                echo "mode: atomic" > coverage.txt
+                grep -h -v "mode: atomic" coverage_*.txt >> coverage.txt
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v1.0.3

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -26,10 +26,15 @@ jobs:
         run: $(go env GOPATH)/bin/golangci-lint run -c .golangci.yml
 
       - name: Run unit tests
-        run: go test -tags=unit -v -coverprofile=coverage.txt -covermode=atomic -race ./...
+        run: go test -tags=unit -v -coverprofile=coverage_unit.txt -covermode=atomic -race ./...
 
       - name: Run integration tests
-        run: go test -tags=integration -v -coverprofile=coverage.txt -covermode=atomic -timeout=60m -parallel 1 ./...
+        run: go test -tags=integration -v -coverprofile=coverage_integration.txt -covermode=atomic -timeout=60m -parallel 1 ./...
+
+      - name: Concat coverage
+        run: |
+        echo "mode: atomic" > coverage.txt
+        grep -h -v "mode: atomic" coverage_*.txt >> coverage.txt
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v1.0.3


### PR DESCRIPTION
In PR #332, I separate tests into 2 runs: 1 for unit tests, and 1 for integration tests. The second test run currently overwrites the coverage report from the first test run. This PR merges the 2 coverage results instead.