### PR TITLE
Add nonce_updated event

### DIFF
--- a/api/mod_ws_integration_test.go
+++ b/api/mod_ws_integration_test.go
@@ -22,6 +22,7 @@
 package api
 
 import (
+	"net/http"
 	"net/url"
 	"strconv"
 	"testing"
@@ -52,66 +53,24 @@ func TestPollLog(t *testing.T) {
 	go gateway.StartHTTP(8080, nil, ledger, keys, kv)
 	defer gateway.Shutdown()
 
-	time.Sleep(100 * time.Millisecond)
-
 	t.Run("tx-tag-filter", func(t *testing.T) {
 		u := url.URL{Scheme: "ws", Host: ":8080", Path: `/poll/tx`, RawQuery: "tag=1"}
-		c, resp, err := websocket.DefaultDialer.Dial(u.String(), nil)
-		if !assert.NoError(t, err) {
-			return
-		}
-
-		defer func() {
-			_ = resp.Body.Close()
-			_ = c.Close()
-		}()
-
-		response := make(chan []byte, 10)
-
-		go func() {
-			for {
-				_, msg, err := c.ReadMessage()
-				if err != nil {
-					return
-				}
-				response <- msg
-			}
-		}()
+		c, cleanup := tryConnectWebsocket(t, u)
+		defer cleanup()
 
 		// log 2 messages with different tags
 		logger := log.TX("test")
 		logger.Log().Uint8("tag", byte(sys.TagTransfer)).Msg("")
-
 		logger.Log().Uint8("tag", byte(sys.TagStake)).Msg("")
 
-		time.Sleep(2500 * time.Millisecond)
-
-		assert.Equal(t, 1, len(response))
+		messages := readAllMessages(t, c, 1)
+		assert.Equal(t, 1, len(messages))
 	})
 
 	t.Run("accounts-grouping", func(t *testing.T) {
 		u := url.URL{Scheme: "ws", Host: ":8080", Path: `/poll/accounts`}
-		c, resp, err := websocket.DefaultDialer.Dial(u.String(), nil)
-		if !assert.NoError(t, err) {
-			return
-		}
-
-		defer func() {
-			_ = resp.Body.Close()
-			_ = c.Close()
-		}()
-
-		response := make(chan []byte, 10)
-
-		go func() {
-			for {
-				_, msg, err := c.ReadMessage()
-				if err != nil {
-					return
-				}
-				response <- msg
-			}
-		}()
+		c, cleanup := tryConnectWebsocket(t, u)
+		defer cleanup()
 
 		// log bunch of messages but only about 2 accounts
 		logger := log.Accounts("test")
@@ -123,13 +82,12 @@ func TestPollLog(t *testing.T) {
 			logger.Log().Str("account_id", id).Msg("")
 		}
 
-		time.Sleep(1000 * time.Millisecond)
-
-		if !assert.Equal(t, 1, len(response)) {
+		messages := readAllMessages(t, c, 1)
+		if !assert.Equal(t, 1, len(messages)) {
 			return
 		}
 
-		v, err := fastjson.Parse(string(<-response))
+		v, err := fastjson.Parse(string(messages[0]))
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -169,15 +127,8 @@ func TestPollNonce(t *testing.T) {
 		Path:   "/poll/accounts",
 	}
 
-	c, resp, err := websocket.DefaultDialer.Dial(u.String(), nil)
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	defer func() {
-		_ = resp.Body.Close()
-		_ = c.Close()
-	}()
+	c, cleanup := tryConnectWebsocket(t, u)
+	defer cleanup()
 
 	_, msg, err := c.ReadMessage()
 	if !assert.NoError(t, err) {
@@ -204,4 +155,57 @@ func TestPollNonce(t *testing.T) {
 	}
 
 	assert.Fail(t, "nonce_updated event not found")
+}
+
+func tryConnectWebsocket(t *testing.T, url url.URL) (*websocket.Conn, func()) {
+	var conn *websocket.Conn
+	var resp *http.Response
+	var err error
+
+	tries := 0
+	tick := time.Tick(time.Second * 1)
+	for range tick {
+		conn, resp, err = websocket.DefaultDialer.Dial(url.String(), nil)
+		if err == nil || (err != nil && tries >= 5) {
+			break
+		}
+
+		tries++
+	}
+
+	assert.NoError(t, err)
+
+	return conn, func() {
+		_ = resp.Body.Close()
+		_ = conn.Close()
+	}
+}
+
+func readAllMessages(t *testing.T, client *websocket.Conn, n int) (messages [][]byte) {
+	messages = make([][]byte, 0)
+
+	ch := make(chan []byte, 10)
+	go func() {
+		for {
+			_, msg, err := client.ReadMessage()
+			if err != nil {
+				return
+			}
+
+			ch <- msg
+		}
+	}()
+
+	for {
+		select {
+		case msg := <-ch:
+			messages = append(messages, msg)
+			if len(messages) == n {
+				return
+			}
+
+		case <-time.After(10 * time.Second):
+			return
+		}
+	}
 }

--- a/cmd/wavelet/events.go
+++ b/cmd/wavelet/events.go
@@ -40,6 +40,7 @@ func setEvents(c *wctl.Client) (func(), error) {
 	c.OnGasBalanceUpdated = onGasBalanceUpdated
 	c.OnStakeUpdated = onStakeUpdated
 	c.OnRewardUpdated = onRewardUpdate
+	c.OnNonceUpdated = onNonceUpdated
 	if err := addToCloser(&toClose)(c.PollAccounts()); err != nil {
 		return cleanup, err
 	}
@@ -162,6 +163,13 @@ func onRewardUpdate(u wctl.RewardUpdated) {
 		Hex("public_key", u.AccountID[:]).
 		Uint64("reward", u.Reward).
 		Msg("Reward updated.")
+}
+
+func onNonceUpdated(u wctl.NonceUpdated) {
+	logger.Info().
+		Hex("public_key", u.AccountID[:]).
+		Uint64("nonce", u.Nonce).
+		Msg("Nonce updated.")
 }
 
 func onPeerJoin(u wctl.PeerJoin) {

--- a/collapse.go
+++ b/collapse.go
@@ -21,6 +21,7 @@ package wavelet
 
 import (
 	"encoding/hex"
+
 	"github.com/perlin-network/wavelet/avl"
 	"github.com/perlin-network/wavelet/log"
 	"github.com/perlin-network/wavelet/lru"
@@ -35,6 +36,7 @@ func collapseTransactions(txs []*Transaction, block *Block, accounts *Accounts) 
 	res.applied = make([]*Transaction, 0, len(txs))
 	res.rejected = make([]*Transaction, 0, len(txs))
 	res.rejectedErrors = make([]error, 0, len(txs))
+	res.accountNonces = make(map[AccountID]uint64)
 
 	ctx := NewCollapseContext(res.snapshot)
 
@@ -54,7 +56,11 @@ func collapseTransactions(txs []*Transaction, block *Block, accounts *Accounts) 
 		if !exists {
 			ctx.WriteAccountsLen(ctx.ReadAccountsLen() + 1)
 		}
+
 		ctx.WriteAccountNonce(tx.Sender, nonce+1)
+
+		// Keep track of latest nonce of each account
+		res.accountNonces[tx.Sender] = nonce + 1
 
 		if hex.EncodeToString(tx.Sender[:]) != sys.FaucetAddress {
 			fee := tx.Fee()

--- a/ledger.go
+++ b/ledger.go
@@ -1424,6 +1424,7 @@ type collapseResults struct {
 	applied        []*Transaction
 	rejected       []*Transaction
 	rejectedErrors []error
+	accountNonces  map[AccountID]uint64
 
 	appliedCount  int
 	rejectedCount int
@@ -1488,6 +1489,14 @@ func (l *Ledger) collapseTransactions(block *Block, logging bool) (*collapseResu
 
 		for i, tx := range collapseState.results.rejected {
 			logEventTX("rejected", tx, collapseState.results.rejectedErrors[i])
+		}
+
+		logger := log.Accounts("nonce_updated")
+		for accountID, nonce := range collapseState.results.accountNonces {
+			logger.Log().
+				Hex("account_id", accountID[:]).
+				Uint64("nonce", nonce).
+				Msg("Nonce updated")
 		}
 	}
 

--- a/testutil.go
+++ b/testutil.go
@@ -329,6 +329,14 @@ func (l *TestLedger) Client() *skademlia.Client {
 	return l.client
 }
 
+func (l *TestLedger) KV() store.KV {
+	return l.kv
+}
+
+func (l *TestLedger) Keys() *skademlia.Keypair {
+	return l.ledger.client.Keys()
+}
+
 func (l *TestLedger) PrivateKey() edwards25519.PrivateKey {
 	keys := l.ledger.client.Keys()
 	return keys.PrivateKey()

--- a/wctl/wctl.go
+++ b/wctl/wctl.go
@@ -106,6 +106,7 @@ type Client struct {
 	OnNumPagesUpdated
 	OnStakeUpdated
 	OnRewardUpdated
+	OnNonceUpdated
 
 	// Network
 	OnPeerJoin

--- a/wctl/ws_accounts.go
+++ b/wctl/ws_accounts.go
@@ -25,6 +25,8 @@ func (c *Client) PollAccounts() (func(), error) {
 				err = parseAccountStakeUpdated(c, o)
 			case "reward_updated":
 				err = parseAccountRewardUpdated(c, o)
+			case "nonce_updated":
+				err = parseAccountNonceUpdated(c, o)
 			default:
 				err = errInvalidEvent(o, ev)
 			}
@@ -129,6 +131,25 @@ func parseAccountRewardUpdated(c *Client, v *fastjson.Value) error {
 
 	if c.OnRewardUpdated != nil {
 		c.OnRewardUpdated(a)
+	}
+	return nil
+}
+
+func parseAccountNonceUpdated(c *Client, v *fastjson.Value) error {
+	var a NonceUpdated
+
+	if err := jsonHex(v, a.AccountID[:], "account_id"); err != nil {
+		return err
+	}
+
+	if err := jsonTime(v, &a.Time, "time"); err != nil {
+		return err
+	}
+
+	a.Nonce = v.GetUint64("nonce")
+
+	if c.OnNonceUpdated != nil {
+		c.OnNonceUpdated(a)
 	}
 	return nil
 }

--- a/wctl/ws_callbacks.go
+++ b/wctl/ws_callbacks.go
@@ -43,6 +43,13 @@ type (
 		Time      time.Time `json:"time"`
 	}
 	OnRewardUpdated = func(RewardUpdated)
+
+	NonceUpdated struct {
+		AccountID [32]byte  `json:"account_id"`
+		Nonce     uint64    `json:"nonce"`
+		Time      time.Time `json:"time"`
+	}
+	OnNonceUpdated = func(NonceUpdated)
 )
 
 // Mod: network


### PR DESCRIPTION
This PR adds `nonce_updated` under `accounts` log module, which the client can use to get the updated nonce for an account.

- [x] Implement the logging
- [x] Add tests