### PR TITLE
Optimize logging collapse results

### DIFF
--- a/api/mod.go
+++ b/api/mod.go
@@ -769,7 +769,7 @@ func (g *Gateway) registerWebsocketSink(rawURL string, factory *debounce.Factory
 	}
 
 	sink := &sink{
-		ops:     make(chan func(map[*client]struct{})),
+		ops: make(chan func(map[*client]struct{})),
 		filters: filters,
 		join:    make(chan *client),
 		leave:   make(chan *client),

--- a/api/mod.go
+++ b/api/mod.go
@@ -769,7 +769,7 @@ func (g *Gateway) registerWebsocketSink(rawURL string, factory *debounce.Factory
 	}
 
 	sink := &sink{
-		ops: make(chan func(map[*client]struct{})),
+		ops:     make(chan func(map[*client]struct{})),
 		filters: filters,
 		join:    make(chan *client),
 		leave:   make(chan *client),

--- a/api/mod_ws_integration_test.go
+++ b/api/mod_ws_integration_test.go
@@ -41,6 +41,7 @@ func TestPollLog(t *testing.T) {
 	gateway := New()
 	gateway.setup()
 
+	log.ClearWriters()
 	log.SetWriter(log.LoggerWebsocket, gateway)
 
 	keys, err := skademlia.NewKeys(1, 1)

--- a/cmd/wavelet/main.go
+++ b/cmd/wavelet/main.go
@@ -64,8 +64,7 @@ func main() {
 }
 
 func Run(args []string, stdin io.ReadCloser, stdout io.Writer, disableGC bool) {
-	log.SetWriter(log.LoggerWavelet, log.NewConsoleWriter(
-		stdout, log.FilterFor(log.ModuleNode)))
+	log.SetWriter(log.LoggerWavelet, log.NewConsoleWriter(stdout, log.FilterFor(log.ModuleNode)))
 
 	app := cli.NewApp()
 

--- a/genesis_integration_test.go
+++ b/genesis_integration_test.go
@@ -196,8 +196,6 @@ func compareTree(t *testing.T, expected *avl.Tree, actual *avl.Tree, checkContra
 }
 
 func TestPerformInception(t *testing.T) {
-	t.Parallel()
-
 	tree := avl.New(store.NewInmem())
 	block := performInception(tree, &testRestoreDir)
 

--- a/ledger.go
+++ b/ledger.go
@@ -93,6 +93,8 @@ type Ledger struct {
 	queryBlockCache map[[blake2b.Size256]byte]*Block
 
 	queueWorkerPool *WorkerPool
+
+	collapseResultsLogger *CollapseResultsLogger
 }
 
 type config struct {
@@ -191,6 +193,8 @@ func NewLedger(kv store.KV, client *skademlia.Client, opts ...Option) *Ledger {
 		queryBlockCache: make(map[BlockID]*Block),
 
 		queueWorkerPool: NewWorkerPool(),
+
+		collapseResultsLogger: NewCollapseResultsLogger(),
 	}
 
 	if !cfg.GCDisabled {
@@ -246,6 +250,8 @@ func (l *Ledger) Close() {
 	l.queueWorkerPool.Stop()
 
 	l.stallDetector.Stop()
+
+	l.collapseResultsLogger.Stop()
 
 	l.stopWG.Wait()
 }
@@ -1482,13 +1488,7 @@ func (l *Ledger) collapseTransactions(block *Block, logging bool) (*collapseResu
 	})
 
 	if logging && collapseState.results != nil {
-		for _, tx := range collapseState.results.applied {
-			logEventTX("applied", tx)
-		}
-
-		for i, tx := range collapseState.results.rejected {
-			logEventTX("rejected", tx, collapseState.results.rejectedErrors[i])
-		}
+		l.collapseResultsLogger.Log(collapseState.results)
 	}
 
 	return collapseState.results, collapseState.err

--- a/log.go
+++ b/log.go
@@ -20,22 +20,143 @@
 package wavelet
 
 import (
+	"encoding/hex"
+	"sync"
+	"time"
+
+	"github.com/perlin-network/wavelet/conf"
 	"github.com/perlin-network/wavelet/log"
+	"github.com/valyala/fastjson"
 )
 
-func logEventTX(event string, tx *Transaction, other ...interface{}) {
-	logger := log.TX(event)
-	log := logger.Log().
-		Hex("tx_id", tx.ID[:]).
-		Hex("sender_id", tx.Sender[:]).
-		Uint8("tag", byte(tx.Tag))
+// CollapseResultsLogger is used to write CollapseResults to the logger's writers.
+//
+// It writes directly into the writers without going through zerolog.
+// The reason is that, zerolog will write into all the writers, even the writer's module does not match with the message's module.
+//
+// It also has a buffer to prevent blocking, as writing all the transactions in a collapse result may take sometime.
+// A collapse result may contain tens of thousands of transactions.
+type CollapseResultsLogger struct {
+	arena         *fastjson.Arena
+	mod           []byte // "tx"
+	eventApplied  []byte // "applied"
+	eventRejected []byte // "rejected"
+	timeLayout    string // "2006-01-02T15:04:05Z07:00"
 
-	for _, o := range other {
-		switch o := o.(type) { // nolint:gocritic
-		case error:
-			log = log.Err(o)
-		}
+	bufTxID     []byte
+	bufSenderID []byte
+	bufTime     []byte
+
+	// Buffer for a batch of messages (many transactions)
+	bufBatch [][]byte
+
+	flushCh chan [][]byte
+
+	stopWg sync.WaitGroup
+	stop   chan struct{}
+	closed bool
+}
+
+func NewCollapseResultsLogger() *CollapseResultsLogger {
+	c := &CollapseResultsLogger{
+		arena:         &fastjson.Arena{},
+		mod:           []byte("tx"),
+		eventApplied:  []byte("applied"),
+		eventRejected: []byte("rejected"),
+		timeLayout:    "2006-01-02T15:04:05Z07:00",
+		bufTxID:       make([]byte, hex.EncodedLen(SizeTransactionID)),
+		bufSenderID:   make([]byte, hex.EncodedLen(SizeAccountID)),
+		bufTime:       make([]byte, 0, 64),
+
+		bufBatch: make([][]byte, 0, conf.GetBlockTXLimit()/4),
+		flushCh:  make(chan [][]byte, 1024),
+
+		stop: make(chan struct{}),
 	}
 
-	log.Msg("")
+	c.stopWg.Add(1)
+	go func() {
+		defer c.stopWg.Done()
+
+		mod := string(c.mod)
+
+		for {
+			// Make stop higher priority.
+			// To prevent the runtime from repeatedly selecting flush channel when the stop channel has been closed.
+			select {
+			case <-c.stop:
+				return
+			default:
+			}
+
+			select {
+			case b := <-c.flushCh:
+				for i := range b {
+					_ = log.Write(mod, b[i])
+				}
+			case <-c.stop:
+				return
+			}
+		}
+	}()
+
+	return c
+}
+
+func (c *CollapseResultsLogger) Log(results *collapseResults) {
+	timestamp := time.Now()
+
+	for _, tx := range results.applied {
+		c.add(tx, c.eventApplied, timestamp, nil)
+	}
+
+	for i, tx := range results.rejected {
+		c.add(tx, c.eventRejected, timestamp, results.rejectedErrors[i])
+	}
+
+	c.flush()
+}
+
+func (c *CollapseResultsLogger) add(tx *Transaction, event []byte, timestamp time.Time, logError error) {
+	o := c.arena.NewObject()
+
+	o.Set("mod", c.arena.NewStringBytes(c.mod))
+	o.Set("event", c.arena.NewStringBytes(event))
+	o.Set("time", c.arena.NewStringBytes(timestamp.AppendFormat(c.bufTime, c.timeLayout)))
+	o.Set("tag", c.arena.NewNumberInt(int(tx.Tag)))
+
+	_ = hex.Encode(c.bufTxID, tx.ID[:])
+	o.Set("tx_id", c.arena.NewStringBytes(c.bufTxID))
+
+	_ = hex.Encode(c.bufSenderID, tx.Sender[:])
+	o.Set("sender_id", c.arena.NewStringBytes(c.bufSenderID))
+
+	if logError != nil {
+		o.Set("error", c.arena.NewString(logError.Error()))
+	}
+
+	// The length of the JSON is 227, not including the error field.
+	buf := make([]byte, 0, 256)
+	c.bufBatch = append(c.bufBatch, o.MarshalTo(buf))
+
+	c.bufTime = c.bufTime[:0]
+	c.arena.Reset()
+}
+
+func (c *CollapseResultsLogger) flush() {
+	c.flushCh <- c.bufBatch
+
+	c.bufBatch = make([][]byte, 0, cap(c.bufBatch))
+}
+
+func (c *CollapseResultsLogger) Stop() {
+	if c.closed {
+		return
+	}
+
+	close(c.stop)
+	c.stopWg.Wait()
+
+	close(c.flushCh)
+	c.closed = true
 }

--- a/log/io.go
+++ b/log/io.go
@@ -37,12 +37,12 @@ func (t *multiWriter) SetWriter(key string, writer io.Writer, modules ...string)
 	t.writers[key] = writer
 
 	if len(modules) == 0 {
+		t.writersModules[key] = nil
 		return
 	}
 
-	if t.writersModules[key] == nil {
-		t.writersModules[key] = make(map[string]struct{})
-	}
+	// Make sure to clear the existing modules if the writer already exists.
+	t.writersModules[key] = make(map[string]struct{})
 
 	for i := range modules {
 		t.writersModules[key][modules[i]] = struct{}{}

--- a/log/io.go
+++ b/log/io.go
@@ -26,7 +26,7 @@ import (
 
 type multiWriter struct {
 	sync.RWMutex
-	writers map[string]io.Writer
+	writers        map[string]io.Writer
 	writersModules map[string]map[string]struct{}
 }
 
@@ -68,7 +68,7 @@ func (t *multiWriter) WriteFilter(p []byte, module string) (n int, err error) {
 	defer t.RUnlock()
 
 	for k, w := range t.writers {
-		writerModules, _ := t.writersModules[k]
+		writerModules := t.writersModules[k]
 		if writerModules != nil {
 			if _, exist := writerModules[module]; !exist {
 				continue

--- a/log/io.go
+++ b/log/io.go
@@ -62,6 +62,14 @@ func (t *multiWriter) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
+func (t *multiWriter) Clear() {
+	t.Lock()
+	defer t.Unlock()
+
+	t.writers = make(map[string]io.Writer)
+	t.writersModules = make(map[string]map[string]struct{})
+}
+
 // WriteFilter writes to only writers that have filter for the module.
 func (t *multiWriter) WriteFilter(p []byte, module string) (n int, err error) {
 	t.RLock()

--- a/log/mod.go
+++ b/log/mod.go
@@ -105,6 +105,10 @@ func SetWriter(key string, writer io.Writer) {
 	output.SetWriter(key, writer, modules...)
 }
 
+func ClearWriters() {
+	output.Clear()
+}
+
 func Node() zerolog.Logger {
 	return node
 }

--- a/log/mod.go
+++ b/log/mod.go
@@ -27,7 +27,8 @@ import (
 
 var (
 	output = &multiWriter{
-		writers: make(map[string]io.Writer),
+		writers:        make(map[string]io.Writer),
+		writersModules: make(map[string]map[string]struct{}),
 	}
 	logger = zerolog.New(output).With().Timestamp().Logger()
 
@@ -95,7 +96,13 @@ func SetLevel(ls string) {
 }
 
 func SetWriter(key string, writer io.Writer) {
-	output.SetWriter(key, writer)
+	var modules []string
+	if cw, ok := writer.(ConsoleWriter); ok {
+		for k := range cw.FilteredModules {
+			modules = append(modules, k)
+		}
+	}
+	output.SetWriter(key, writer, modules...)
 }
 
 func Node() zerolog.Logger {
@@ -132,4 +139,10 @@ func Sync(event string) zerolog.Logger {
 
 func Metrics() zerolog.Logger {
 	return metrics
+}
+
+// Write to only the writers that have filter for the module.
+func Write(module string, msg []byte) error {
+	_, err := output.WriteFilter(msg, module)
+	return err
 }

--- a/log_test.go
+++ b/log_test.go
@@ -5,7 +5,6 @@ package wavelet
 import (
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -63,7 +62,6 @@ func TestCollapseResultsLogger(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		select {
 		case b := <-logCh:
-			fmt.Println(string(b))
 			outputs = append(outputs, b)
 		case <-time.After(100 * time.Millisecond):
 			assert.FailNow(t, "timeout waiting for message", "expected 2 messages, timeout at %d", i)

--- a/log_test.go
+++ b/log_test.go
@@ -29,7 +29,7 @@ func TestCollapseResultsLogger(t *testing.T) {
 
 	results := &collapseResults{}
 
-	payload, err := Transfer{Recipient: recipient.PublicKey(), Amount: 1,}.Marshal()
+	payload, err := Transfer{Recipient: recipient.PublicKey(), Amount: 1}.Marshal()
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -37,7 +37,7 @@ func TestCollapseResultsLogger(t *testing.T) {
 	results.appliedCount++
 	results.applied = append(results.applied, &txApplied)
 
-	payload, err = Transfer{Recipient: recipient.PublicKey(), Amount: 10,}.Marshal()
+	payload, err = Transfer{Recipient: recipient.PublicKey(), Amount: 10}.Marshal()
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -48,7 +48,6 @@ func TestCollapseResultsLogger(t *testing.T) {
 
 	logCh := make(chan []byte)
 	log.SetWriter("tx", writerFunc(func(p []byte) (n int, err error) {
-
 		logCh <- p
 		return len(p), nil
 	}))

--- a/log_test.go
+++ b/log_test.go
@@ -49,8 +49,8 @@ func TestCollapseResultsLogger(t *testing.T) {
 	results.rejected = append(results.rejected, &txRejected)
 	results.rejectedErrors = append(results.rejectedErrors, errors.New("error rejected"))
 
-	logCh := make(chan []byte)
-	log.SetWriter("tx", writerFunc(func(p []byte) (n int, err error) {
+	logCh := make(chan []byte, 2)
+	log.SetWriter("tx_write_test", writerFunc(func(p []byte) (n int, err error) {
 		logCh <- p
 		return len(p), nil
 	}))

--- a/log_test.go
+++ b/log_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestCollapseResultsLogger(t *testing.T) {
+	log.ClearWriters()
+
 	logger := NewCollapseResultsLogger()
 
 	keys, err := skademlia.NewKeys(1, 1)

--- a/log_test.go
+++ b/log_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestCollapseResultsLogger(t *testing.T) {
 	log.ClearWriters()
+	defer log.ClearWriters()
 
 	logger := NewCollapseResultsLogger()
 

--- a/log_test.go
+++ b/log_test.go
@@ -1,0 +1,107 @@
+package wavelet
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/perlin-network/noise/skademlia"
+	"github.com/perlin-network/wavelet/log"
+	"github.com/perlin-network/wavelet/sys"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fastjson"
+)
+
+func TestCollapseResultsLogger(t *testing.T) {
+	logger := NewCollapseResultsLogger()
+
+	keys, err := skademlia.NewKeys(1, 1)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	recipient, err := skademlia.NewKeys(1, 1)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	results := &collapseResults{}
+
+	payload, err := Transfer{Recipient: recipient.PublicKey(), Amount: 1,}.Marshal()
+	if !assert.NoError(t, err) {
+		return
+	}
+	txApplied := NewTransaction(keys, 0, 0, sys.TagTransfer, payload)
+	results.appliedCount++
+	results.applied = append(results.applied, &txApplied)
+
+	payload, err = Transfer{Recipient: recipient.PublicKey(), Amount: 10,}.Marshal()
+	if !assert.NoError(t, err) {
+		return
+	}
+	txRejected := NewTransaction(keys, 0, 0, sys.TagTransfer, payload)
+	results.rejectedCount++
+	results.rejected = append(results.rejected, &txRejected)
+	results.rejectedErrors = append(results.rejectedErrors, errors.New("error rejected"))
+
+	logCh := make(chan []byte)
+	log.SetWriter("tx", writerFunc(func(p []byte) (n int, err error) {
+
+		logCh <- p
+		return len(p), nil
+	}))
+
+	logger.Log(results)
+
+	var outputs [][]byte
+	// Wait for the log messages
+	for i := 0; i < 2; i++ {
+		select {
+		case b := <-logCh:
+			fmt.Println(string(b))
+			outputs = append(outputs, b)
+		case <-time.After(100 * time.Millisecond):
+			assert.FailNow(t, "timeout waiting for message", "expected 2 messages, timeout at %d", i)
+		}
+	}
+
+	// Check the first tx
+
+	v, err := fastjson.ParseBytes(outputs[0])
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, "tx", string(v.GetStringBytes("mod")))
+	assert.Equal(t, "applied", string(v.GetStringBytes("event")))
+	assert.Equal(t, hex.EncodeToString(txApplied.ID[:]), string(v.GetStringBytes("tx_id")))
+	assert.Equal(t, hex.EncodeToString(txApplied.Sender[:]), string(v.GetStringBytes("sender_id")))
+	assert.Nil(t, v.GetStringBytes("error"))
+
+	// Check the second tx
+
+	v, err = fastjson.ParseBytes(outputs[1])
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, "tx", string(v.GetStringBytes("mod")))
+	assert.Equal(t, "rejected", string(v.GetStringBytes("event")))
+	assert.Equal(t, hex.EncodeToString(txRejected.ID[:]), string(v.GetStringBytes("tx_id")))
+	assert.Equal(t, hex.EncodeToString(txRejected.Sender[:]), string(v.GetStringBytes("sender_id")))
+	assert.Equal(t, "error rejected", string(v.GetStringBytes("error")))
+
+	// Call twice, the second call should have no effect.
+	logger.Stop()
+	logger.Stop()
+
+	assert.True(t, logger.closed)
+	_, ok := <-logger.flushCh
+	assert.False(t, ok)
+}
+
+type writerFunc func(p []byte) (n int, err error)
+
+func (w writerFunc) Write(p []byte) (n int, err error) {
+	return w(p)
+}

--- a/log_test.go
+++ b/log_test.go
@@ -1,3 +1,5 @@
+// +build !integration,unit
+
 package wavelet
 
 import (

--- a/snowball_test.go
+++ b/snowball_test.go
@@ -87,7 +87,6 @@ func getRandomID(t *testing.T) *skademlia.ID {
 }
 
 func TestSnowball(t *testing.T) {
-	t.Parallel()
 	snowballBeta := 10
 	defaultBeta := conf.GetSnowballBeta()
 	conf.Update(conf.WithSnowballBeta(snowballBeta))
@@ -272,7 +271,6 @@ func TestSnowball(t *testing.T) {
 // Test if all tallies have equal value and the value is lower than alpha.
 // Snowball will never decide.
 func TestSnowball_EqualTally_LowerThanAlpha(t *testing.T) {
-	t.Parallel()
 	snowballBeta := 10
 	defaultBeta := conf.GetSnowballBeta()
 	conf.Update(conf.WithSnowballBeta(snowballBeta))
@@ -326,7 +324,6 @@ func TestSnowball_EqualTally_LowerThanAlpha(t *testing.T) {
 //
 // Nevertheless, because of the way the snowball is implemented, if this happens, the snowball will prefer the first vote.
 func TestSnowball_EqualTally_HigherThanAlpha(t *testing.T) {
-	t.Parallel()
 	snowballBeta := 10
 	defaultBeta := conf.GetSnowballBeta()
 	conf.Update(conf.WithSnowballBeta(snowballBeta))


### PR DESCRIPTION
There's a serious performance issue on the logging of collapse results. 
This performance issue can be severe when there are more than 10,000 transactions in a block. And it can have cascading impact on the performance of finalization (at least on my machine).

As you can see below, it can take more than 1 second to log a collapse result.
(The number in brackets is the number of transactions)

```
»»» logging collapse results (3946) took 76.556821ms
»»» logging collapse results (24215) took 472.709766ms
»»» logging collapse results (3927) took 69.653531ms
»»» logging collapse results (20420) took 470.434397ms
»»» logging collapse results (8291) took 177.229131ms
»»» logging collapse results (26042) took 503.408222ms
»»» logging collapse results (22277) took 455.032903ms
»»» logging collapse results (21466) took 492.797458ms
»»» logging collapse results (24661) took 551.213992ms
»»» logging collapse results (25779) took 657.309561ms
»»» logging collapse results (30573) took 715.361155ms
»»» logging collapse results (24427) took 603.267018ms
»»» logging collapse results (38552) took 869.41173ms
»»» logging collapse results (28388) took 2.282205659s
»»» logging collapse results (52269) took 2.0052882s
»»» logging collapse results (45526) took 688.535743ms
```

There are two issues with the logging that are causing performance issue.
1. The logging is a blocking process. Each transaction will be be serialized into json and write into the writers.

2. The logger will write on all the writers, even the writer's module does not match with the message's module. Currently, we have two writers.
I believe zerologger will filter the messages during the output.

However, I don't think there's any performance issue with the JSON serialization of zerolog library.

We did not notice this issue because the log was only recently enabled.

This PR fixes the performance issue by using buffer and write only to filtered writers.
We treat the `tx` event as a special case of logging, by not using zerolog.
The buffer is set 1024, this should give enough time for the writers to catch up, especially the `api` module (`websocket`) to handle the messages.

Below is the improved performance
```
»»» logging collapse results 5000 took 9.690248ms
»»» logging collapse results 27360 took 60.670627ms
»»» logging collapse results 4436 took 7.36232ms
»»» logging collapse results 22118 took 74.11094ms
»»» logging collapse results 4902 took 9.104645ms
»»» logging collapse results 21460 took 35.103805ms
»»» logging collapse results 1120 took 2.097708ms
»»» logging collapse results 13728 took 22.835278ms
»»» logging collapse results 9108 took 15.836429ms
»»» logging collapse results 5850 took 12.59921ms
»»» logging collapse results 8986 took 15.298364ms
»»» logging collapse results 7211 took 12.542619ms
»»» logging collapse results 6409 took 22.77037ms
»»» logging collapse results 6344 took 12.720952ms
»»» logging collapse results 9889 took 17.036898ms
»»» logging collapse results 3167 took 5.38616ms
```