### PR TITLE
Test improvements and experiments.

### DIFF
--- a/accounts_test.go
+++ b/accounts_test.go
@@ -19,41 +19,38 @@
 
 package wavelet
 
-//import (
-//	"bytes"
-//	"fmt"
-//	"math/rand"
-//	"testing"
-//	"testing/quick"
-//	"time"
-//
-//	"github.com/perlin-network/wavelet/store"
-//	"github.com/stretchr/testify/assert"
-//)
-//
-//func TestSmartContract(t *testing.T) {
-//	fn := func(id TransactionID, code [2 * 1024]byte) bool {
-//		accounts := NewAccounts(store.NewInmem())
-//		tree := accounts.Snapshot()
-//
-//		returned, available := ReadAccountContractCode(tree, id)
-//		if returned != nil || available == true {
-//			return false
-//		}
-//
-//		WriteAccountContractCode(tree, id, code[:])
-//
-//		returned, available = ReadAccountContractCode(tree, id)
-//		if !bytes.Equal(code[:], returned) || available == false {
-//			return false
-//		}
-//
-//		return true
-//	}
-//
-//	assert.NoError(t, quick.Check(fn, nil))
-//}
-//
+import (
+	"bytes"
+	"testing"
+	"testing/quick"
+
+	"github.com/perlin-network/wavelet/store"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSmartContract(t *testing.T) {
+	fn := func(id TransactionID, code [2 * 1024]byte) bool {
+		accounts := NewAccounts(store.NewInmem())
+		tree := accounts.Snapshot()
+
+		returned, available := ReadAccountContractCode(tree, id)
+		if returned != nil || available == true {
+			return false
+		}
+
+		WriteAccountContractCode(tree, id, code[:])
+
+		returned, available = ReadAccountContractCode(tree, id)
+		if !bytes.Equal(code[:], returned) || available == false {
+			return false
+		}
+
+		return true
+	}
+
+	assert.NoError(t, quick.Check(fn, nil))
+}
+
 //func BenchmarkAccountsCommit(b *testing.B) {
 //	dbs := []string{"level"}
 //

--- a/ledger_integration_test.go
+++ b/ledger_integration_test.go
@@ -74,7 +74,7 @@ func TestLedger_PayInsufficientBalance(t *testing.T) {
 		return
 	}
 
-	alice.WaitUntilConsensus(t)
+	alice.WaitUntilBlock(t, 2)
 
 	// Alice should have paid for gas even though the tx failed
 	waitFor(t, func() bool {
@@ -171,7 +171,7 @@ func TestLedger_CallContract(t *testing.T) {
 		10000, nil)
 	assert.NoError(t, err)
 
-	alice.WaitUntilConsensus(t)
+	alice.WaitUntilBlock(t, 2)
 
 	// Calling the contract should cause the contract to send back 250000 PERL back to alice
 	_, err = alice.CallContract(
@@ -204,7 +204,7 @@ func TestLedger_DepositGas(t *testing.T) {
 		10000, nil)
 	assert.NoError(t, err)
 
-	alice.WaitUntilConsensus(t)
+	alice.WaitUntilBlock(t, 2)
 
 	_, err = alice.DepositGas(contract.ID, 654321)
 	if !assert.NoError(t, err) {
@@ -264,7 +264,7 @@ func TestLedger_Sync(t *testing.T) {
 			return
 		}
 
-		alice.WaitUntilConsensus(t)
+		alice.WaitUntilBlock(t, uint64(i+1))
 	}
 
 	testnet.WaitForBlock(t, alice.BlockIndex())

--- a/testutil.go
+++ b/testutil.go
@@ -155,7 +155,13 @@ func (n *TestNetwork) WaitForBlock(t testing.TB, block uint64) {
 		close(done)
 	}()
 
-	<-done
+	select {
+	case <-time.After(time.Second * 10):
+		t.Fatal("timed out waiting for block")
+
+	case <-done:
+		return
+	}
 }
 
 func (n *TestNetwork) WaitForConsensus(t testing.TB) {
@@ -185,9 +191,17 @@ func (n *TestNetwork) WaitForConsensus(t testing.TB) {
 		close(done)
 	}()
 
-	<-done
-	close(stop)
-	return
+	timer := time.NewTimer(10 * time.Second)
+	select {
+	case <-done:
+		close(stop)
+		return
+
+	case <-timer.C:
+		close(stop)
+		<-done
+		t.Fatal("consensus took too long")
+	}
 }
 
 func (n *TestNetwork) WaitForSync(t testing.TB) {
@@ -206,8 +220,13 @@ func (n *TestNetwork) WaitForSync(t testing.TB) {
 		close(done)
 	}()
 
-	<-done
-	return
+	timer := time.NewTimer(30 * time.Second)
+	select {
+	case <-done:
+		return
+	case <-timer.C:
+		t.Fatal("timeout while waiting for all nodes to be synced")
+	}
 }
 
 func (n *TestNetwork) WaitUntilSync(t testing.TB) {
@@ -402,10 +421,15 @@ func (l *TestLedger) WaitForConsensus() <-chan bool {
 	ch := make(chan bool)
 	go func() {
 		start := l.ledger.Blocks().Latest()
+		timeout := time.NewTimer(time.Second * 3)
 		ticker := time.NewTicker(time.Millisecond * 5)
 
 		for {
 			select {
+			case <-timeout.C:
+				ch <- false
+				return
+
 			case <-ticker.C:
 				current := l.ledger.Blocks().Latest()
 				if current.Index > start.Index {
@@ -422,10 +446,16 @@ func (l *TestLedger) WaitForConsensus() <-chan bool {
 func (l *TestLedger) WaitUntilConsensus(t testing.TB) {
 	t.Helper()
 
+	timeout := time.NewTimer(time.Second * 30)
 	for {
-		c := <-l.WaitForConsensus()
-		if c {
-			return
+		select {
+		case c := <-l.WaitForConsensus():
+			if c {
+				return
+			}
+
+		case <-timeout.C:
+			t.Fatal("timed out waiting for consensus")
 		}
 	}
 }
@@ -436,12 +466,16 @@ func (l *TestLedger) WaitUntilBalance(t testing.TB, balance uint64) {
 	t.Helper()
 
 	ticker := time.NewTicker(time.Millisecond * 200)
+	timeout := time.NewTimer(time.Second * 300)
 	for {
 		select {
 		case <-ticker.C:
 			if l.Balance() == balance {
 				return
 			}
+
+		case <-timeout.C:
+			t.Fatal("timed out waiting for balance")
 		}
 	}
 }
@@ -450,12 +484,16 @@ func (l *TestLedger) WaitUntilStake(t testing.TB, stake uint64) {
 	t.Helper()
 
 	ticker := time.NewTicker(time.Millisecond * 200)
+	timeout := time.NewTimer(time.Second * 300)
 	for {
 		select {
 		case <-ticker.C:
 			if l.Stake() == stake {
 				return
 			}
+
+		case <-timeout.C:
+			t.Fatal("timed out waiting for stake")
 		}
 	}
 }
@@ -463,10 +501,15 @@ func (l *TestLedger) WaitUntilStake(t testing.TB, stake uint64) {
 func (l *TestLedger) WaitForBlock(index uint64) <-chan uint64 {
 	ch := make(chan uint64)
 	go func() {
+		timeout := time.NewTimer(time.Second * 3)
 		ticker := time.NewTicker(time.Millisecond * 10)
 
 		for {
 			select {
+			case <-timeout.C:
+				ch <- 0
+				return
+
 			case <-ticker.C:
 				current := l.ledger.Blocks().Latest()
 				if current.Index >= index {
@@ -483,12 +526,16 @@ func (l *TestLedger) WaitForBlock(index uint64) <-chan uint64 {
 func (l *TestLedger) WaitUntilBlock(t testing.TB, block uint64) {
 	t.Helper()
 
+	timeout := time.NewTimer(time.Second * 300)
 	for {
 		select {
 		case ri := <-l.WaitForBlock(block):
 			if ri >= block {
 				return
 			}
+
+		case <-timeout.C:
+			t.Fatal("timed out waiting for block")
 		}
 	}
 }
@@ -496,9 +543,14 @@ func (l *TestLedger) WaitUntilBlock(t testing.TB, block uint64) {
 func (l *TestLedger) WaitForSync() <-chan bool {
 	ch := make(chan bool)
 	go func() {
+		timeout := time.NewTimer(time.Second * 30)
 		ticker := time.NewTicker(time.Millisecond * 50)
 		for {
 			select {
+			case <-timeout.C:
+				ch <- false
+				return
+
 			case <-ticker.C:
 				if l.ledger.SyncStatus() == "Node is fully synced" {
 					ch <- true
@@ -514,10 +566,16 @@ func (l *TestLedger) WaitForSync() <-chan bool {
 func (l *TestLedger) WaitUntilSync(t testing.TB) {
 	t.Helper()
 
+	timeout := time.NewTimer(time.Second * 30)
 	for {
-		s := <-l.WaitForSync()
-		if s {
-			return
+		select {
+		case s := <-l.WaitForSync():
+			if s {
+				return
+			}
+
+		case <-timeout.C:
+			t.Fatal("timed out waiting for sync")
 		}
 	}
 }
@@ -696,10 +754,14 @@ func loadKeys(t testing.TB, wallet string) *skademlia.Keypair {
 func waitFor(t testing.TB, fn func() bool) {
 	t.Helper()
 
+	timeout := time.NewTimer(time.Second * 30)
 	ticker := time.NewTicker(time.Millisecond * 100)
 
 	for {
 		select {
+		case <-timeout.C:
+			t.Fatal("timed out waiting")
+
 		case <-ticker.C:
 			if fn() {
 				return


### PR DESCRIPTION
This is a WIP PR that contains improvements and some experiments to improve testing on the CI.

- `WaitUntilConsensus` sometimes times out, especially if you run the tests locally. My guess is this happens when the test environment is too fast, and one consensus block managed to happen before the call to `WaitUntilConsensus`. Instead, use `WaitUntilBlock` and explicitly specify the block index the test is waiting for.
- Remove all timeouts from test methods. Global test timeout is used instead.