### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ COPY go.sum /src/go.sum
 RUN (cd /src; go mod download)
 
 ADD . /src
-RUN (cd /src/cmd/wavelet; go build)
-RUN (cd /src/cmd/benchmark; go build)
+RUN (cd /src/cmd/wavelet; CGO_ENABLED=0 go build)
+RUN (cd /src/cmd/benchmark; CGO_ENABLED=0 go build)
 
 FROM alpine:3.9
 


### PR DESCRIPTION
As part of adding BadgerDB support, CGO can be used for ZSTD compression;  Disable it while building the Docker image