### PR TITLE
Fix failing genesis tests

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -28,11 +28,11 @@ jobs:
       - name: Run unit tests
         run: make unit_test
 
-      - name: Run integration tests
-        run: make integration_test
-
       - name: Run genesis tests
         run: go test -v -tags=integration -parallel 1 . -run TestDump
+
+      - name: Run integration tests
+        run: make integration_test
 
       - name: Concat coverage
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Run unit tests
         run: make unit_test
 
-      - name: Run genesis tests
-        run: go test -v -tags=integration -parallel 1 . -run TestDump
-
       - name: Run integration tests
         run: make integration_test
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Run integration tests
         run: make integration_test
 
+      - name: Run genesis tests
+        run: go test -v -tags=integration -parallel 1 . -run TestDump
+
       - name: Concat coverage
         run: |
                 echo "mode: atomic" > coverage.txt

--- a/genesis_integration_test.go
+++ b/genesis_integration_test.go
@@ -51,8 +51,7 @@ func getGenesisTestNetwork(t testing.TB, withContract bool) (testnet *TestNetwor
 	alice = testnet.AddNode(t)
 	bob := testnet.AddNode(t)
 
-	alice.WaitUntilSync(t)
-	bob.WaitUntilSync(t)
+	testnet.WaitUntilSync(t)
 
 	var err error
 
@@ -72,20 +71,24 @@ func getGenesisTestNetwork(t testing.TB, withContract bool) (testnet *TestNetwor
 	assert.NoError(t, err)
 	bob.WaitUntilStake(t, 100)
 
+	block := alice.BlockIndex()
+
 	if withContract {
 		for i := 0; i < 3; i++ {
 			tx, err := alice.SpawnContract("testdata/transfer_back.wasm", 10000, nil)
 			if !assert.NoError(t, err) {
 				return nil, nil, cleanup
 			}
-			alice.WaitUntilConsensus(t)
+			block++
+			alice.WaitUntilBlock(t, block)
 
 			if i%2 == 0 {
 				tx, err = alice.DepositGas(tx.ID, (uint64(i)+1)*100)
 				if !assert.NoError(t, err) {
 					return nil, nil, cleanup
 				}
-				alice.WaitUntilConsensus(t)
+				block++
+				alice.WaitUntilBlock(t, block)
 			}
 		}
 	}


### PR DESCRIPTION
The tests are flaky because it does not properly wait for all nodes to sync, and uses `WaitUntilConsensus` instead of `WaitUntilBlock`.