### PR TITLE
Github CI improvements.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -24,9 +24,6 @@ jobs:
       - name: Build for 32 bit arm
         run: GOOS=linux GOARCH=arm go build -o wavelet-linux-arm ./cmd/wavelet
 
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
-
       - name: Install golangci-lint
         run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.20.1
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Cache go modules
         uses: actions/cache@v1
         with:
-          path: $(go env GOPATH)/pkg/mod
+          path: /home/runner/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,8 +17,6 @@ jobs:
         with:
           path: /home/runner/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
 
       - name: Download Go modules
         run: go mod download -json

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -18,9 +18,6 @@ jobs:
           path: $(go env GOPATH)/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
-      - name: Download Go modules
-        run: go mod download
-
       - name: Build for linux
         run: GOOS=linux GOARCH=amd64 go build -o wavelet-linux-amd64 ./cmd/wavelet
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Cache go modules
         uses: actions/cache@v1
         with:
-          path: ~/go/pkg/mod
+          path: $(go env GOPATH)/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           path: $(go env GOPATH)/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Build for linux
         run: GOOS=linux GOARCH=amd64 go build -o wavelet-linux-amd64 ./cmd/wavelet

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,16 +6,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
           go-version: '1.13.3'
+
+      - name: Cache go modules
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Download Go modules
         run: go mod download
+
       - name: Build for linux
         run: GOOS=linux GOARCH=amd64 go build -o wavelet-linux-amd64 ./cmd/wavelet
+
       - name: Build for 32 bit arm
         run: GOOS=linux GOARCH=arm go build -o wavelet-linux-arm ./cmd/wavelet
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,8 +17,6 @@ jobs:
         with:
           path: $(go env GOPATH)/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
 
       - name: Download Go modules
         run: go mod download

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -20,6 +20,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
+      - name: Download Go modules
+        run: go mod download
+
       - name: Build for linux
         run: GOOS=linux GOARCH=amd64 go build -o wavelet-linux-amd64 ./cmd/wavelet
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -21,7 +21,7 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Download Go modules
-        run: go mod download
+        run: go mod download -json
 
       - name: Build for linux
         run: GOOS=linux GOARCH=amd64 go build -o wavelet-linux-amd64 ./cmd/wavelet

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: coverage_unit
-          path: coverage.txt
+          path: coverage_unit.txt
 
   integration_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,7 +2,7 @@ name: CI
 on: [push]
 
 jobs:
-  run_unit_tests:
+  unit_tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -19,7 +19,89 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
       - name: Download Go modules
-        run: go mod download -json
+        run: go mod download
+
+      - name: Run unit tests
+        run: make unit_test
+
+      - name: Save code coverage
+        uses: actions/upload-artifact@v1
+        with:
+          name: coverage_unit
+          path: coverage.txt
+
+  integration_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.3'
+
+      - name: Cache go modules
+        uses: actions/cache@v1
+        with:
+          path: /home/runner/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Download Go modules
+        run: go mod download
+
+      - name: Run integration tests
+        run: make integration_test
+
+      - name: Save code coverage
+        uses: actions/upload-artifact@v1
+        with:
+          name: coverage_integration
+          path: coverage_integration.txt
+
+  code_coverage:
+    runs-on: ubuntu-latest
+    needs: [unit_tests, integration_tests]
+    steps:
+      - name: Download unit tests code coverage
+        uses: actions/download-artifact@v1
+        with:
+          name: coverage_unit
+          path: .
+
+      - name: Download integration tests code coverage
+        uses: actions/download-artifact@v1
+        with:
+          name: coverage_integration
+          path: .
+
+      - name: Concat coverage
+        run: |
+                echo "mode: atomic" > coverage.txt
+                grep -h -v "mode: atomic" coverage_*.txt >> coverage.txt
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v1.0.3
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}
+          file: coverage.txt
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.3'
+
+      - name: Cache go modules
+        uses: actions/cache@v1
+        with:
+          path: /home/runner/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Download Go modules
+        run: go mod download
 
       - name: Build for linux
         run: GOOS=linux GOARCH=amd64 go build -o wavelet-linux-amd64 ./cmd/wavelet
@@ -32,20 +114,3 @@ jobs:
 
       - name: Run golangci-lint
         run: $(go env GOPATH)/bin/golangci-lint run -c .golangci.yml
-
-      - name: Run unit tests
-        run: make unit_test
-
-      - name: Run integration tests
-        run: make integration_test
-
-      - name: Concat coverage
-        run: |
-                echo "mode: atomic" > coverage.txt
-                grep -h -v "mode: atomic" coverage_*.txt >> coverage.txt
-
-      - name: Upload coverage report
-        uses: codecov/codecov-action@v1.0.3
-        with:
-          token: ${{secrets.CODECOV_TOKEN}}
-          file: coverage.txt


### PR DESCRIPTION
Few improvements to speed up CI cycle:

- [x] Cache go installation (looks like this is already handled by the action)
- [x] Cache go modules
- [x] Cache linter installation (it takes 2 seconds to install the linter, so I don't think there's much room to improve)
- [x] Split into multiple jobs to take advantage of parallelization