### PR TITLE
Separate usage of the "api.host" flag

### DIFF
--- a/cmd/wavelet/main.go
+++ b/cmd/wavelet/main.go
@@ -113,15 +113,15 @@ func Run(args []string, stdin io.ReadCloser, stdout io.Writer, disableGC bool) {
 			EnvVar: "WAVELET_API_PORT",
 		}),
 		altsrc.NewStringFlag(cli.StringFlag{
-			Name:   "wctl.host",
+			Name:   "cli.host",
 			Usage:  "Host to reach to manage the node.",
-			EnvVar: "WAVELET_WCTL_HOST",
+			EnvVar: "WAVELET_CLI_HOST",
 		}),
 		altsrc.NewUintFlag(cli.UintFlag{
-			Name:   "wctl.port",
+			Name:   "cli.port",
 			Value:  0,
 			Usage:  "Port to connect to to manage the node.",
-			EnvVar: "WAVELET_WCTL_PORT",
+			EnvVar: "WAVELET_CLI_PORT",
 		}),
 		altsrc.NewStringFlag(cli.StringFlag{
 			Name:   "api.host",
@@ -315,14 +315,16 @@ func start(c *cli.Context, stdin io.ReadCloser, stdout io.Writer, disableGC bool
 		}()
 
 		wctlCfg.Server = srv
-		if c.Uint("wctl.port") != 0 {
-			wctlCfg.APIPort = uint16(c.Uint("wctl.port"))
+
+		if c.Uint("cli.port") != 0 {
+			wctlCfg.APIPort = uint16(c.Uint("cli.port"))
 		} else {
 			wctlCfg.APIPort = uint16(c.Uint("api.port"))
 		}
 
 		wctlCfg.PrivateKey = srv.Keys.PrivateKey()
-		wctlCfg.APIHost = c.String("wctl.host")
+		wctlCfg.APIHost = c.String("cli.host")
+
 		if wctlCfg.APIHost == "" {
 			wctlCfg.APIHost = "127.0.0.1"
 		} else {

--- a/cmd/wavelet/main.go
+++ b/cmd/wavelet/main.go
@@ -117,6 +117,12 @@ func Run(args []string, stdin io.ReadCloser, stdout io.Writer, disableGC bool) {
 			Usage:  "Host to reach to manage the node.",
 			EnvVar: "WAVELET_WCTL_HOST",
 		}),
+		altsrc.NewUintFlag(cli.UintFlag{
+			Name:   "wctl.port",
+			Value:  0,
+			Usage:  "Port to connect to to manage the node.",
+			EnvVar: "WAVELET_WCTL_PORT",
+		}),
 		altsrc.NewStringFlag(cli.StringFlag{
 			Name:   "api.host",
 			Usage:  "Host for the API HTTPS node.",
@@ -309,7 +315,11 @@ func start(c *cli.Context, stdin io.ReadCloser, stdout io.Writer, disableGC bool
 		}()
 
 		wctlCfg.Server = srv
-		wctlCfg.APIPort = uint16(c.Uint("api.port"))
+		if c.Uint("wctl.port") != 0 {
+			wctlCfg.APIPort = uint16(c.Uint("wctl.port"))
+		} else {
+			wctlCfg.APIPort = uint16(c.Uint("api.port"))
+		}
 		wctlCfg.PrivateKey = srv.Keys.PrivateKey()
 
 		wctlCfg.APIHost = c.String("wctl.host")

--- a/cmd/wavelet/main.go
+++ b/cmd/wavelet/main.go
@@ -113,6 +113,11 @@ func Run(args []string, stdin io.ReadCloser, stdout io.Writer, disableGC bool) {
 			EnvVar: "WAVELET_API_PORT",
 		}),
 		altsrc.NewStringFlag(cli.StringFlag{
+			Name:   "wctl.host",
+			Usage:  "Host to reach to manage the node.",
+			EnvVar: "WAVELET_WCTL_HOST",
+		}),
+		altsrc.NewStringFlag(cli.StringFlag{
 			Name:   "api.host",
 			Usage:  "Host for the API HTTPS node.",
 			EnvVar: "WAVELET_API_HOST",
@@ -307,7 +312,7 @@ func start(c *cli.Context, stdin io.ReadCloser, stdout io.Writer, disableGC bool
 		wctlCfg.APIPort = uint16(c.Uint("api.port"))
 		wctlCfg.PrivateKey = srv.Keys.PrivateKey()
 
-		wctlCfg.APIHost = c.String("api.host")
+		wctlCfg.APIHost = c.String("wctl.host")
 		if wctlCfg.APIHost == "" {
 			wctlCfg.APIHost = "127.0.0.1"
 		} else {

--- a/cmd/wavelet/main.go
+++ b/cmd/wavelet/main.go
@@ -320,8 +320,8 @@ func start(c *cli.Context, stdin io.ReadCloser, stdout io.Writer, disableGC bool
 		} else {
 			wctlCfg.APIPort = uint16(c.Uint("api.port"))
 		}
-		wctlCfg.PrivateKey = srv.Keys.PrivateKey()
 
+		wctlCfg.PrivateKey = srv.Keys.PrivateKey()
 		wctlCfg.APIHost = c.String("wctl.host")
 		if wctlCfg.APIHost == "" {
 			wctlCfg.APIHost = "127.0.0.1"


### PR DESCRIPTION
Use a separate flag to specify the host wctl should connect to versus… the one we want to allow for HTTPS API access