### PR TITLE
Remove duplicated dump entry in help, and add alias

### DIFF
--- a/cmd/wavelet/cli.go
+++ b/cmd/wavelet/cli.go
@@ -277,17 +277,7 @@ func NewCLI(client *wctl.Client, opts ...func(cli *CLI)) (*CLI, error) {
 		{
 			Name:        "dump",
 			Action:      a(c.dump),
-			Description: "dump wallet states, and you may use -c to dump contract code and pages",
-			Flags: []cli.Flag{
-				cli.BoolFlag{
-					Name:  "c",
-					Usage: "dump contract code and pages",
-				},
-			},
-		},
-		{
-			Name:        "dump",
-			Action:      a(c.dump),
+			Aliases:     []string{"d"},
 			Description: "dump wallet states, and you may use -c to dump contract code and pages",
 			Flags: []cli.Flag{
 				cli.BoolFlag{


### PR DESCRIPTION
Dump command appears twice under `help`. And because it has no alias, it looks weird with empty bracket:
![2019-12-09_12-08](https://user-images.githubusercontent.com/1431045/70406711-979ae880-1a7c-11ea-8629-a2869e7a1d73.png)