### PR TITLE
fix(Docker): Add git version to docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,12 @@ COPY go.mod /src/go.mod
 COPY go.sum /src/go.sum
 RUN (cd /src; go mod download)
 
+ARG GIT_COMMIT
+ENV GIT_COMMIT=$GIT_COMMIT
+
 ADD . /src
-RUN (cd /src/cmd/wavelet; CGO_ENABLED=0 go build)
+RUN (echo "${GIT_COMMIT}")
+RUN (cd /src/cmd/wavelet; CGO_ENABLED=0 go build -ldflags "-X github.com/perlin-network/wavelet/sys.GitCommit=${GIT_COMMIT}")
 RUN (cd /src/cmd/benchmark; CGO_ENABLED=0 go build)
 
 FROM alpine:3.9

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ BINOUT = $(shell pwd)/build
 
 R = localhost:5000
 T = latest
+G = $(shell git rev-parse --short HEAD)
 
 protoc:
 	protoc --gogofaster_out=plugins=grpc:. -I=. rpc.proto
@@ -34,7 +35,7 @@ upload:
 	rsync -avz cmd/graph/main root@104.248.44.250:/root
 
 docker:
-	docker build -t wavelet:$(T) .
+	docker build --build-arg=GIT_COMMIT=$(G) -t wavelet:$(T) .
 ifneq ($(R),)
 	docker tag wavelet:$(T) $(R)/wavelet:$(T)
 	docker push $(R)/wavelet:$(T)


### PR DESCRIPTION
Currently, the wavelet stack is not guaranteed to deploy the latest image if it is not explicitly tagged. This adds the git commit ref to the docker image, so that we can easily check it in the ctl and ensure that the expected build is deployed.