### PR TITLE
Fix memory leak in arena allocation in API, temporarily remove API message debouncing, and speed up logging state changes.

### DIFF
--- a/api/mod.go
+++ b/api/mod.go
@@ -21,7 +21,6 @@ package api
 
 import (
 	"bytes"
-	"context"
 	"crypto/tls"
 	"encoding/hex"
 	"fmt"
@@ -37,7 +36,6 @@ import (
 	"github.com/buaazp/fasthttprouter"
 	"github.com/perlin-network/noise/skademlia"
 	"github.com/perlin-network/wavelet"
-	"github.com/perlin-network/wavelet/internal/debounce"
 	"github.com/perlin-network/wavelet/log"
 	"github.com/perlin-network/wavelet/store"
 	"github.com/perlin-network/wavelet/sys"
@@ -87,27 +85,12 @@ func New() *Gateway {
 
 func (g *Gateway) setup() {
 	// Setup websocket logging sinks.
-	sinkNetwork := g.registerWebsocketSink("ws://network/", nil)
-	sinkConsensus := g.registerWebsocketSink("ws://consensus/", nil)
-	sinkAccounts := g.registerWebsocketSink("ws://accounts/?id=account_id",
-		debounce.NewFactory(debounce.TypeDeduper,
-			debounce.WithPeriod(500*time.Millisecond),
-			debounce.WithKeys("account_id", "event"),
-		),
-	)
-	sinkContracts := g.registerWebsocketSink("ws://contract/?id=contract_id",
-		debounce.NewFactory(debounce.TypeDeduper,
-			debounce.WithPeriod(500*time.Millisecond),
-			debounce.WithKeys("contract_id"),
-		),
-	)
-	sinkTransactions := g.registerWebsocketSink("ws://tx/?id=tx_id&sender=sender_id&tag=tag",
-		debounce.NewFactory(debounce.TypeLimiter,
-			debounce.WithPeriod(2200*time.Millisecond),
-			debounce.WithBufferLimit(1638400),
-		),
-	)
-	sinkMetrics := g.registerWebsocketSink("ws://metrics/", nil)
+	sinkNetwork := g.registerWebsocketSink("ws://network/")
+	sinkConsensus := g.registerWebsocketSink("ws://consensus/")
+	sinkAccounts := g.registerWebsocketSink("ws://accounts/?id=account_id")
+	sinkContracts := g.registerWebsocketSink("ws://contract/?id=contract_id")
+	sinkTransactions := g.registerWebsocketSink("ws://tx/?id=tx_id&sender=sender_id&tag=tag")
+	sinkMetrics := g.registerWebsocketSink("ws://metrics/")
 
 	log.SetWriter(log.LoggerWebsocket, g)
 
@@ -737,7 +720,7 @@ func (g *Gateway) poll(sink *sink) func(ctx *fasthttp.RequestCtx) {
 	}
 }
 
-func (g *Gateway) registerWebsocketSink(rawURL string, factory *debounce.Factory) *sink {
+func (g *Gateway) registerWebsocketSink(rawURL string) *sink {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		panic(err)
@@ -756,10 +739,6 @@ func (g *Gateway) registerWebsocketSink(rawURL string, factory *debounce.Factory
 		filters: filters,
 		join:    make(chan *client),
 		leave:   make(chan *client),
-	}
-
-	if factory != nil {
-		sink.debouncer = factory.Init(context.Background(), debounce.WithAction(sink.debounce))
 	}
 
 	go sink.run()
@@ -803,6 +782,7 @@ func (g *Gateway) Write(buf []byte) (n int, err error) {
 func (g *Gateway) render(ctx *fasthttp.RequestCtx, m marshalableJSON) {
 	arena := g.arenaPool.Get()
 	b, err := m.marshalJSON(arena)
+	arena.Reset()
 	g.arenaPool.Put(arena)
 
 	if err != nil {

--- a/api/mod.go
+++ b/api/mod.go
@@ -751,9 +751,10 @@ func (g *Gateway) registerWebsocketSink(rawURL string) *sink {
 }
 
 func (g *Gateway) Write(buf []byte) (n int, err error) {
-	var p fastjson.Parser
-
+	p := g.parserPool.Get()
 	v, err := p.ParseBytes(buf)
+	g.parserPool.Put(p)
+
 	if err != nil {
 		return n, errors.Errorf("cannot parse: %q", err)
 	}

--- a/api/mod.go
+++ b/api/mod.go
@@ -798,6 +798,7 @@ func (g *Gateway) render(ctx *fasthttp.RequestCtx, m marshalableJSON) {
 func (g *Gateway) renderError(ctx *fasthttp.RequestCtx, e *errResponse) {
 	arena := g.arenaPool.Get()
 	b := e.marshalJSON(arena)
+	arena.Reset()
 	g.arenaPool.Put(arena)
 
 	ctx.SetContentType("application/json")

--- a/api/ws.go
+++ b/api/ws.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/fasthttp/websocket"
-	"github.com/perlin-network/wavelet/internal/debounce"
 	"github.com/valyala/fasthttp"
 	"github.com/valyala/fastjson"
 )
@@ -150,8 +149,6 @@ type sink struct {
 	filters map[string]string
 
 	join, leave chan *client
-
-	debouncer debounce.Debouncer
 }
 
 func (s *sink) run() {
@@ -196,58 +193,9 @@ SENDING:
 	}
 }
 
-func (s *sink) debounce(batch [][]byte) {
-	f := func(clients map[*client]struct{}) {
-	SENDING:
-		for c := range clients {
-			idx, obj := 0, fastjson.MustParse("[]")
-
-		BATCHING:
-			for _, buf := range batch {
-				o, err := fastjson.ParseBytes(buf)
-				if err != nil {
-					continue BATCHING
-				}
-
-				for key, condition := range c.filters {
-					val := o.Get(key)
-
-					if val == nil {
-						continue BATCHING
-					}
-
-					if !fastjsonEquals(val, condition) {
-						continue BATCHING
-					}
-				}
-
-				obj.SetArrayItem(idx, o)
-				idx++
-			}
-
-			if idx == 0 {
-				continue SENDING
-			}
-
-			buf := obj.MarshalTo(nil)
-
-			select {
-			case c.queue <- buf:
-			default:
-			}
-		}
-	}
-
-	s.ops <- f
-}
-
 func (s *sink) broadcast(item broadcastItem) {
-	if s.debouncer != nil {
-		s.debouncer.Add(debounce.Bytes(item.buf))
-	} else {
-		s.ops <- func(clients map[*client]struct{}) {
-			s.doSend(clients, item.buf, item.value)
-		}
+	s.ops <- func(clients map[*client]struct{}) {
+		s.doSend(clients, item.buf, item.value)
 	}
 }
 

--- a/collapse.go
+++ b/collapse.go
@@ -141,7 +141,6 @@ type CollapseContext struct {
 	contractVMs         map[AccountID]*VMState
 
 	rewardWithdrawalRequests []RewardWithdrawalRequest
-	finalizedTransactions    []*Transaction
 
 	VMCache *VMLRU
 }
@@ -384,8 +383,6 @@ func (c *CollapseContext) Flush() error {
 // Apply a transaction by writing the states into memory.
 // After you've finished, you MUST call CollapseContext.Flush() to actually write the states into the tree.
 func (c *CollapseContext) ApplyTransaction(block *Block, tx *Transaction) error {
-	c.finalizedTransactions = append(c.finalizedTransactions, tx)
-
 	if err := applyTransaction(block, c, tx, &contractExecutorState{
 		GasPayer: tx.Sender,
 	}); err != nil {

--- a/collapse.go
+++ b/collapse.go
@@ -119,7 +119,7 @@ func collapseTransactions(
 		return res, err
 	}
 
-	//ctx.processFinalizedTransactions(block.Index, txs)
+	res.ctx.processFinalizedTransactions(block.Index, txs)
 
 	return res, nil
 }

--- a/collapse.go
+++ b/collapse.go
@@ -20,10 +20,8 @@
 package wavelet
 
 import (
-	"encoding/binary"
 	"encoding/hex"
 	"github.com/perlin-network/wavelet/avl"
-	"github.com/perlin-network/wavelet/conf"
 	"github.com/perlin-network/wavelet/log"
 	"github.com/perlin-network/wavelet/sys"
 	"github.com/pkg/errors"
@@ -119,7 +117,7 @@ func collapseTransactions(
 		return res, err
 	}
 
-	res.ctx.processFinalizedTransactions(block.Index, txs)
+	//res.ctx.processFinalizedTransactions(block.Index, txs)
 
 	return res, nil
 }
@@ -317,30 +315,30 @@ func (c *CollapseContext) processRewardWithdrawals(blockIndex uint64) {
 	c.rewardWithdrawalRequests = leftovers
 }
 
-func (c *CollapseContext) processFinalizedTransactions(height uint64, finalized []*Transaction) {
-	pruningLimit := uint64(conf.GetPruningLimit())
-
-	if height < pruningLimit {
-		return
-	}
-
-	heightLimit := height - pruningLimit
-
-	cb := func(k, v []byte) bool {
-		height := binary.BigEndian.Uint64(k[:8])
-
-		if height <= heightLimit {
-			c.tree.Delete(append(keyTransactionFinalized[:], k...))
-			return true
-		}
-
-		return false
-	}
-
-	c.tree.IteratePrefix(keyTransactionFinalized[:], cb)
-
-	StoreFinalizedTransactionIDs(c.tree, height, finalized)
-}
+//func (c *CollapseContext) processFinalizedTransactions(height uint64, finalized []*Transaction) {
+//	pruningLimit := uint64(conf.GetPruningLimit())
+//
+//	if height < pruningLimit {
+//		return
+//	}
+//
+//	heightLimit := height - pruningLimit
+//
+//	cb := func(k, v []byte) bool {
+//		height := binary.BigEndian.Uint64(k[:8])
+//
+//		if height <= heightLimit {
+//			c.tree.Delete(append(keyTransactionFinalized[:], k...))
+//			return true
+//		}
+//
+//		return false
+//	}
+//
+//	c.tree.IteratePrefix(keyTransactionFinalized[:], cb)
+//
+//	StoreFinalizedTransactionIDs(c.tree, height, finalized)
+//}
 
 // Write the changes into the tree.
 func (c *CollapseContext) Flush() error {

--- a/ledger.go
+++ b/ledger.go
@@ -22,7 +22,6 @@ package wavelet
 import (
 	"bytes"
 	"context"
-	"encoding/binary"
 	"encoding/hex"
 	"github.com/perlin-network/noise"
 	"github.com/perlin-network/noise/skademlia"
@@ -793,7 +792,7 @@ func (l *Ledger) finalize(block Block) {
 	l.metrics.acceptedTX.Mark(int64(results.appliedCount))
 	l.metrics.finalizedBlocks.Mark(1)
 
-	l.LogChanges(results.snapshot, current.Index)
+	l.LogChanges(results)
 
 	// Reset sampler(s).
 	l.finalizer.Reset()
@@ -948,11 +947,7 @@ type collapseResults struct {
 	rejectedCount int
 
 	snapshot *avl.Tree
-}
-
-type CollapseState struct {
-	results *collapseResults
-	err     error
+	ctx      *CollapseContext
 }
 
 // collapseTransactions takes all transactions recorded within a block, and applies all valid
@@ -962,83 +957,60 @@ type CollapseState struct {
 func (l *Ledger) collapseTransactions(
 	height uint64, current *Block, proposed []TransactionID, logging bool,
 ) (*collapseResults, error) {
-	state := &CollapseState{}
-
 	transactions, err := l.transactions.BatchFind(proposed)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not find transactions to collapse in node")
 	}
 
-	state.results, state.err = collapseTransactions(height, transactions, current, l.accounts)
-	if state.err != nil {
-		return nil, errors.Wrap(state.err, "failed to collapse transactions")
+	results, err := collapseTransactions(height, transactions, current, l.accounts)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to collapse transactions")
 	}
 
-	if logging && state.results != nil {
-		l.collapseResultsLogger.Log(state.results)
+	if logging && results != nil {
+		l.collapseResultsLogger.Log(results)
 	}
 
-	return state.results, state.err
+	return results, err
 }
 
 // LogChanges logs all changes made to an AVL tree state snapshot for the purposes
 // of logging out changes to account state to Wavelet's HTTP API.
-func (l *Ledger) LogChanges(snapshot *avl.Tree, lastBlockIndex uint64) {
+func (l *Ledger) LogChanges(c *collapseResults) {
 	balanceLogger := log.Accounts("balance_updated")
 	gasBalanceLogger := log.Accounts("gas_balance_updated")
 	stakeLogger := log.Accounts("stake_updated")
 	rewardLogger := log.Accounts("reward_updated")
-	numPagesLogger := log.Accounts("num_pages_updated")
 
-	balanceKey := append(keyAccounts[:], keyAccountBalance[:]...)
-	gasBalanceKey := append(keyAccounts[:], keyAccountContractGasBalance[:]...)
-	stakeKey := append(keyAccounts[:], keyAccountStake[:]...)
-	rewardKey := append(keyAccounts[:], keyAccountReward[:]...)
-	numPagesKey := append(keyAccounts[:], keyAccountContractNumPages[:]...)
-
-	var id AccountID
-
-	snapshot.IterateLeafDiff(lastBlockIndex, func(key, value []byte) bool {
-		switch {
-		case bytes.HasPrefix(key, balanceKey):
-			copy(id[:], key[len(balanceKey):])
-
+	for _, id := range c.ctx.accountIDs {
+		if bal, ok := c.ctx.balances[id]; ok {
 			balanceLogger.Log().
 				Hex("account_id", id[:]).
-				Uint64("balance", binary.LittleEndian.Uint64(value)).
-				Msg("")
-		case bytes.HasPrefix(key, gasBalanceKey):
-			copy(id[:], key[len(gasBalanceKey):])
-
-			gasBalanceLogger.Log().
-				Hex("account_id", id[:]).
-				Uint64("gas_balance", binary.LittleEndian.Uint64(value)).
-				Msg("")
-		case bytes.HasPrefix(key, stakeKey):
-			copy(id[:], key[len(stakeKey):])
-
-			stakeLogger.Log().
-				Hex("account_id", id[:]).
-				Uint64("stake", binary.LittleEndian.Uint64(value)).
-				Msg("")
-		case bytes.HasPrefix(key, rewardKey):
-			copy(id[:], key[len(rewardKey):])
-
-			rewardLogger.Log().
-				Hex("account_id", id[:]).
-				Uint64("reward", binary.LittleEndian.Uint64(value)).
-				Msg("")
-		case bytes.HasPrefix(key, numPagesKey):
-			copy(id[:], key[len(numPagesKey):])
-
-			numPagesLogger.Log().
-				Hex("account_id", id[:]).
-				Uint64("num_pages", binary.LittleEndian.Uint64(value)).
+				Uint64("balance", bal).
 				Msg("")
 		}
 
-		return true
-	})
+		if stake, ok := c.ctx.stakes[id]; ok {
+			stakeLogger.Log().
+				Hex("account_id", id[:]).
+				Uint64("stake", stake).
+				Msg("")
+		}
+
+		if reward, ok := c.ctx.rewards[id]; ok {
+			rewardLogger.Log().
+				Hex("account_id", id[:]).
+				Uint64("reward", reward).
+				Msg("")
+		}
+
+		if gasBal, ok := c.ctx.contractGasBalances[id]; ok {
+			gasBalanceLogger.Log().
+				Hex("account_id", id[:]).
+				Uint64("gas_balance", gasBal).
+				Msg("")
+		}
+	}
 }
 
 // filterInvalidVotes takes a slice of (*finalizationVote)'s and filters away

--- a/wctl/ws.go
+++ b/wctl/ws.go
@@ -57,6 +57,7 @@ func (c *Client) pollWS(path string, callback func(*fastjson.Value)) (func(), er
 
 			go func(message []byte) {
 				p := c.jsonPool.Get()
+				defer c.jsonPool.Put(p)
 
 				o, err := p.ParseBytes(message)
 				if err != nil {
@@ -65,8 +66,6 @@ func (c *Client) pollWS(path string, callback func(*fastjson.Value)) (func(), er
 				}
 
 				callback(o)
-
-				c.jsonPool.Put(p)
 			}(message)
 		}
 	}()

--- a/wctl/ws_accounts.go
+++ b/wctl/ws_accounts.go
@@ -3,36 +3,34 @@ package wctl
 import "github.com/valyala/fastjson"
 
 func (c *Client) PollAccounts() (func(), error) {
-	return c.pollWS(RouteWSAccounts, func(v *fastjson.Value) {
+	return c.pollWS(RouteWSAccounts, func(o *fastjson.Value) {
 		var err error
 
-		for _, o := range v.GetArray() {
-			if err := checkMod(o, "accounts"); err != nil {
-				if c.OnError != nil {
-					c.OnError(err)
-				}
-				continue
+		if err := checkMod(o, "accounts"); err != nil {
+			if c.OnError != nil {
+				c.OnError(err)
 			}
+			return
+		}
 
-			switch ev := jsonString(o, "event"); ev {
-			case "balance_updated":
-				err = parseAccountsBalanceUpdated(c, o)
-			case "gas_balance_updated":
-				err = parseAccountsGasBalanceUpdated(c, o)
-			case "num_pages_updated":
-				err = parseAccountNumPagesUpdated(c, o)
-			case "stake_updated":
-				err = parseAccountStakeUpdated(c, o)
-			case "reward_updated":
-				err = parseAccountRewardUpdated(c, o)
-			default:
-				err = errInvalidEvent(o, ev)
-			}
+		switch ev := jsonString(o, "event"); ev {
+		case "balance_updated":
+			err = parseAccountsBalanceUpdated(c, o)
+		case "gas_balance_updated":
+			err = parseAccountsGasBalanceUpdated(c, o)
+		case "num_pages_updated":
+			err = parseAccountNumPagesUpdated(c, o)
+		case "stake_updated":
+			err = parseAccountStakeUpdated(c, o)
+		case "reward_updated":
+			err = parseAccountRewardUpdated(c, o)
+		default:
+			err = errInvalidEvent(o, ev)
+		}
 
-			if err != nil {
-				if c.OnError != nil {
-					c.OnError(err)
-				}
+		if err != nil {
+			if c.OnError != nil {
+				c.OnError(err)
 			}
 		}
 	})


### PR DESCRIPTION
1. There were arena allocations that were not being cleaned up which sprung up a memory leak. That got fixed.
2. Stale logs are being debounced to the websocket. Temporarily disable debouncing for the time being in the HTTP API.
3. To prevent ourselves from hitting the database too much, print out changes in state from a CollapseContext instance.

api, wctl: fix memory leak over json parser not being returned to pool
api, ws, wctl: tmp remove debouncing because of stale messages being pushed to websocket
ledger: make LogChanges log changes from a collapse context rather than from the avl tree