### PR TITLE
Add second to log timestamp format

### DIFF
--- a/log/console.go
+++ b/log/console.go
@@ -51,7 +51,7 @@ var (
 		},
 	}
 
-	consoleDefaultTimeFormat = time.Kitchen
+	consoleDefaultTimeFormat = "3:04:05PM"
 
 	consoleDefaultPartsOrder = func() []string {
 		return []string{


### PR DESCRIPTION
This PR adds second to log timestamp format to make it easier to debug.