### PR TITLE
Add log.nocolor flag to disable color in logs

### DIFF
--- a/cmd/wavelet/cli.go
+++ b/cmd/wavelet/cli.go
@@ -54,25 +54,34 @@ type CLI struct {
 
 	client *wctl.Client
 
-	stdin  io.ReadCloser
-	stdout io.Writer
+	stdin   io.ReadCloser
+	stdout  io.Writer
+	nocolor bool
 
 	cleanup func()
 }
 
-func CLIWithStdin(stdin io.ReadCloser) func(cli *CLI) {
+type CLIOption func(cli *CLI)
+
+func CLIWithStdin(stdin io.ReadCloser) CLIOption {
 	return func(cli *CLI) {
 		cli.stdin = stdin
 	}
 }
 
-func CLIWithStdout(stdout io.Writer) func(cli *CLI) {
+func CLIWithStdout(stdout io.Writer) CLIOption {
 	return func(cli *CLI) {
 		cli.stdout = stdout
 	}
 }
 
-func NewCLI(client *wctl.Client, opts ...func(cli *CLI)) (*CLI, error) {
+func CLIWithNoColor(b bool) CLIOption {
+	return func(cli *CLI) {
+		cli.nocolor = b
+	}
+}
+
+func NewCLI(client *wctl.Client, opts ...CLIOption) (*CLI, error) {
 	// Set CLI callbacks, mainly loggers
 	cleanup, err := setEvents(client)
 	if err != nil {
@@ -363,6 +372,7 @@ func NewCLI(client *wctl.Client, opts ...func(cli *CLI)) (*CLI, error) {
 				log.ModuleSync,
 				log.ModuleContract,
 			),
+			log.NoColor(c.nocolor),
 		),
 	)
 

--- a/cmd/wavelet/main.go
+++ b/cmd/wavelet/main.go
@@ -163,6 +163,11 @@ func Run(args []string, stdin io.ReadCloser, stdout io.Writer, disableGC bool) {
 			Usage:  "Minimum log level to output. Possible values: debug, info, warn, error, fatal, panic.",
 			EnvVar: "WAVELET_LOGLEVEL",
 		}),
+		altsrc.NewBoolFlag(cli.BoolFlag{
+			Name:   "log.nocolor",
+			Usage:  "Disable color in log output.",
+			EnvVar: "WAVELET_LOG_NOCOLOR",
+		}),
 		altsrc.NewIntFlag(cli.IntFlag{
 			Name:   "memory.max",
 			Value:  0,
@@ -355,7 +360,12 @@ func start(c *cli.Context, stdin io.ReadCloser, stdout io.Writer, disableGC bool
 		logger.Err(err).Msg("wctl error")
 	}
 
-	shell, err := NewCLI(client, CLIWithStdin(stdin), CLIWithStdout(stdout))
+	opts := []CLIOption{CLIWithStdin(stdin), CLIWithStdout(stdout)}
+	if c.Bool("log.nocolor") {
+		opts = append(opts, CLIWithNoColor(true))
+	}
+
+	shell, err := NewCLI(client, opts...)
 	if err != nil {
 		return fmt.Errorf("failed to spawn the CLI: %v", err)
 	}

--- a/log/console.go
+++ b/log/console.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/rs/zerolog"
 	"io"
 	"os"
 	"sort"
@@ -31,6 +30,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/rs/zerolog"
 )
 
 const (
@@ -101,6 +102,12 @@ func FilterFor(modules ...string) func(w *ConsoleWriter) {
 		for _, module := range modules {
 			w.FilteredModules[module] = struct{}{}
 		}
+	}
+}
+
+func NoColor(b bool) func(w *ConsoleWriter) {
+	return func(w *ConsoleWriter) {
+		w.NoColor = b
 	}
 }
 


### PR DESCRIPTION
This is added to assist debugging, because piping the output of the log with colors makes it slightly unreadable due to the presence of control characters on some text editors.